### PR TITLE
Save all

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,3 +85,4 @@ gem 'bixby'
 # Maybe extract just the stuff for multi-inputs..
 gem 'hydra-editor'
 gem 'jquery-ui-rails', '~> 6.0'
+gem 'ruby-prof'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -365,6 +365,7 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     rubocop-rspec (1.15.0)
       rubocop (>= 0.42.0)
+    ruby-prof (0.16.2)
     ruby-progressbar (1.8.1)
     ruby_dep (1.5.0)
     rubyzip (1.2.1)
@@ -506,6 +507,7 @@ DEPENDENCIES
   rspec-rails
   rubocop
   rubocop-rspec
+  ruby-prof
   sass-rails (~> 5.0)
   shoulda-matchers
   simple_form

--- a/app/persistence/valkyrie/persistence/fedora/persister.rb
+++ b/app/persistence/valkyrie/persistence/fedora/persister.rb
@@ -7,6 +7,12 @@ module Valkyrie::Persistence::Fedora
         instance(model).save
       end
 
+      def save_all(models:)
+        models.map do |model|
+          save(model: model)
+        end
+      end
+
       def delete(model:)
         instance(model).delete
       end

--- a/app/persistence/valkyrie/persistence/memory/persister.rb
+++ b/app/persistence/valkyrie/persistence/memory/persister.rb
@@ -12,6 +12,12 @@ module Valkyrie::Persistence::Memory
       cache[model.id] = inner_model(model)
     end
 
+    def save_all(models:)
+      models.map do |model|
+        save(model: model)
+      end
+    end
+
     def delete(model:)
       cache.delete(model.id)
     end

--- a/app/persistence/valkyrie/persistence/postgres/bulk_syncer.rb
+++ b/app/persistence/valkyrie/persistence/postgres/bulk_syncer.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+module Valkyrie::Persistence::Postgres
+  class BulkSyncer
+    attr_reader :models
+    def initialize(models:)
+      @models = models
+    end
+
+    def save_all
+      new_result = orm_klass.import(new_resources)
+      existing_result = orm_klass.import(existing_resources, on_duplicate_key_update: [:metadata])
+      orm_klass.where(id: (new_result.ids + existing_result.ids)).map do |resource|
+        resource_factory.to_model(resource)
+      end
+    end
+
+    private
+
+      def all_resources
+        new_resources + existing_resources
+      end
+
+      def new_resources
+        @new_resources ||= models.select { |x| !orm_ids.include?(x.id) }.map do |model|
+          resource_factory.from_model(model, resource: orm_klass.new)
+        end
+      end
+
+      def existing_resources
+        @existing_resources ||= orm_resources.map do |resource|
+          resource_factory.from_model(grouped_models[Valkyrie::ID.new(resource.id)].first, resource: resource)
+        end
+      end
+
+      def orm_resources
+        @orm_resources ||= orm_klass.where(id: models.map(&:id))
+      end
+
+      def grouped_models
+        @grouped_resources ||= models.group_by(&:id)
+      end
+
+      def orm_ids
+        @orm_ids ||= orm_resources.map { |x| Valkyrie::ID.new(x.id) }
+      end
+
+      def orm_klass
+        ::Valkyrie::Persistence::Postgres::ORM::Resource
+      end
+
+      def resource_factory
+        Valkyrie::Persistence::Postgres::ResourceFactory
+      end
+  end
+end

--- a/app/persistence/valkyrie/persistence/postgres/persister.rb
+++ b/app/persistence/valkyrie/persistence/postgres/persister.rb
@@ -6,6 +6,10 @@ module Valkyrie::Persistence::Postgres
         instance(model).persist
       end
 
+      def save_all(models:)
+        ::Valkyrie::Persistence::Postgres::BulkSyncer.new(models: models).save_all
+      end
+
       def delete(model:)
         instance(model).delete
       end

--- a/app/persistence/valkyrie/persistence/postgres/resource_factory.rb
+++ b/app/persistence/valkyrie/persistence/postgres/resource_factory.rb
@@ -6,10 +6,10 @@ module Valkyrie::Persistence::Postgres
         ::Valkyrie::Persistence::Postgres::DynamicKlass.new(orm_object.all_attributes)
       end
 
-      def from_model(resource)
-        ::Valkyrie::Persistence::Postgres::ORM::Resource.find_or_initialize_by(id: resource.id.to_s).tap do |orm_object|
-          orm_object.model_type ||= resource.resource_class.to_s
-          orm_object.metadata.merge!(resource.attributes.except(:id))
+      def from_model(model, resource: nil)
+        (resource || ::Valkyrie::Persistence::Postgres::ORM::Resource.find_or_initialize_by(id: model.id.to_s)).tap do |orm_object|
+          orm_object.model_type ||= model.resource_class.to_s
+          orm_object.metadata.merge!(model.attributes.except(:id))
         end
       end
     end

--- a/app/persistence/valkyrie/persistence/solr/persister.rb
+++ b/app/persistence/valkyrie/persistence/solr/persister.rb
@@ -8,21 +8,19 @@ module Valkyrie::Persistence::Solr
     end
 
     def save(model:)
-      repository(model).persist
+      repository(model).persist.first
     end
 
     def save_all(models:)
-      models.map do |model|
-        save(model: model)
-      end
+      repository(models).persist
     end
 
     def delete(model:)
-      repository(model).delete
+      repository(model).delete.first
     end
 
     def repository(model)
-      Valkyrie::Persistence::Solr::Repository.new(model: model, connection: connection, resource_factory: resource_factory)
+      Valkyrie::Persistence::Solr::Repository.new(models: Array.wrap(model), connection: connection, resource_factory: resource_factory)
     end
   end
 end

--- a/app/persistence/valkyrie/persistence/solr/persister.rb
+++ b/app/persistence/valkyrie/persistence/solr/persister.rb
@@ -11,6 +11,12 @@ module Valkyrie::Persistence::Solr
       repository(model).persist
     end
 
+    def save_all(models:)
+      models.map do |model|
+        save(model: model)
+      end
+    end
+
     def delete(model:)
       repository(model).delete
     end

--- a/app/persistence/valkyrie/persistence/solr/repository.rb
+++ b/app/persistence/valkyrie/persistence/solr/repository.rb
@@ -1,29 +1,32 @@
 # frozen_string_literal: true
 module Valkyrie::Persistence::Solr
   class Repository
-    attr_reader :model, :connection, :resource_factory
-    def initialize(model:, connection:, resource_factory:)
-      @model = model
+    attr_reader :models, :connection, :resource_factory
+    def initialize(models:, connection:, resource_factory:)
+      @models = models
       @connection = connection
       @resource_factory = resource_factory
     end
 
     def persist
-      generate_id if model.id.blank?
-      connection.add solr_document, params: { softCommit: true }
-      model
+      documents = models.map do |model|
+        generate_id(model) if model.id.blank?
+        solr_document(model)
+      end
+      connection.add documents, params: { softCommit: true }
+      models
     end
 
     def delete
-      connection.delete_by_id "id-#{model.id}", params: { softCommit: true }
-      model
+      connection.delete_by_id models.map { |model| "id-#{model.id}" }, params: { softCommit: true }
+      models
     end
 
-    def solr_document
+    def solr_document(model)
       resource_factory.from_model(model).to_h
     end
 
-    def inner_model
+    def inner_model(model)
       if model.respond_to?(:model)
         model.model
       else
@@ -31,9 +34,9 @@ module Valkyrie::Persistence::Solr
       end
     end
 
-    def generate_id
+    def generate_id(model)
       Rails.logger.warn "The Solr adapter is not meant to persist new resources, but is now generating an ID."
-      inner_model.id = SecureRandom.uuid
+      inner_model(model).id = SecureRandom.uuid
     end
   end
 end

--- a/app/persisters/appending_persister.rb
+++ b/app/persisters/appending_persister.rb
@@ -12,6 +12,14 @@ class AppendingPersister
     end
   end
 
+  def save_all(models:)
+    persister.save_all(models: models).tap do |result|
+      result.each do |model|
+        append_model(result, model.try(:append_id))
+      end
+    end
+  end
+
   def delete(model:)
     persister.delete(model: model)
   end

--- a/app/persisters/composite_persister.rb
+++ b/app/persisters/composite_persister.rb
@@ -14,6 +14,10 @@ class CompositePersister
     persisters.inject(model) { |m, persister| persister.save(model: m) }
   end
 
+  def save_all(models:)
+    persisters.inject(models) { |m, persister| persister.save_all(models: m) }
+  end
+
   def delete(model:)
     persisters.inject(model) { |m, persister| persister.delete(model: m) }
   end

--- a/app/persisters/parent_cleanup_persister.rb
+++ b/app/persisters/parent_cleanup_persister.rb
@@ -19,6 +19,10 @@ class ParentCleanupPersister
     persister.save(model: model)
   end
 
+  def save_all(models:)
+    persister.save_all(models: models)
+  end
+
   private
 
     attr_reader :persister

--- a/app/persisters/persister.rb
+++ b/app/persisters/persister.rb
@@ -3,14 +3,14 @@ class Persister
   class_attribute :adapter
   self.adapter = Valkyrie.config.adapter
   class << self
-    delegate :save, :delete, :persister, to: :default_adapter
+    delegate :save, :save_all, :delete, :persister, to: :default_adapter
 
     def default_adapter
       new(adapter: adapter)
     end
   end
 
-  delegate :save, :delete, :persister, to: :adapted_persister
+  delegate :save, :save_all, :delete, :persister, to: :adapted_persister
   def initialize(adapter:)
     @adapter = adapter
   end

--- a/lib/valkyrie/specs/shared_specs/persister.rb
+++ b/lib/valkyrie/specs/shared_specs/persister.rb
@@ -25,6 +25,17 @@ RSpec.shared_examples 'a Valkyrie::Persister' do
     expect(persister.save(model: resource).id).not_to be_blank
   end
 
+  it "can save multiple resources" do
+    book1 = persister.save(model: resource_class.new)
+    book1.title = ["Test"]
+    books = [book1, resource_class.new]
+    result = persister.save_all(models: books)
+
+    expect(result.map(&:id).length).to eq 2
+    expect(result.map(&:id).compact).not_to be_blank
+    expect(query_service.find_by(id: book1.id).title).to eq ["Test"]
+  end
+
   it "can handle language-typed RDF properties" do
     book = persister.save(model: resource_class.new(title: ["Test1", RDF::Literal.new("Test", language: :fr)]))
 

--- a/script/benchmarker.rb
+++ b/script/benchmarker.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'benchmark'
 
-num_children = 100
+num_children = 1000
 
 # Pop off the indexing_persister  so we don't test it
 Valkyrie::Adapter.adapters.to_a.each do |adapter_name, adapter|
@@ -10,9 +10,9 @@ Valkyrie::Adapter.adapters.to_a.each do |adapter_name, adapter|
     children = nil
     bench.report("#{adapter_name} create #{num_children} children") do
       children = Array.new(num_children) do |_page_num|
-        p = Page.new
-        adapter.persister.save(model: p)
+        Page.new
       end
+      children = adapter.persister.save_all(models: children)
     end
     parent.member_ids = children.map(&:id)
     bench.report("#{adapter_name} save parent with #{num_children} children") do


### PR DESCRIPTION
@escowles mentioned that adding a `save_all` may enable bulk operation savings for Solr, since it's faster at inserting multiple documents at once. So, I updated the code for save_all performance improvements in both postgres and Solr, and the benchmarks are below (10,000 children):

Benchmarks Before:

```
Running via Spring preloader in process 23881
       user     system      total        real
postgres create 10000 children 15.090000   4.010000  19.100000 ( 23.352669)
postgres save parent with 10000 children  0.440000   0.010000   0.450000 (  0.475266)
postgres reload parent with 10000 children  0.040000   0.000000   0.040000 (  0.047060)
postgres add one more page to a parent with 10000 existing children  0.740000   0.010000   0.750000 (  0.754269)
       user     system      total        real
memory create 10000 children  0.180000   0.000000   0.180000 (  0.179131)
memory save parent with 10000 children  0.000000   0.000000   0.000000 (  0.000049)
memory reload parent with 10000 children  0.000000   0.000000   0.000000 (  0.002659)
memory add one more page to a parent with 10000 existing children  0.000000   0.000000   0.000000 (  0.006263)
       user     system      total        real
index_solr create 10000 children 10.190000   1.960000  12.150000 ( 34.375328)
index_solr save parent with 10000 children  1.130000   0.180000   1.310000 (  1.426888)
index_solr reload parent with 10000 children  0.170000   0.030000   0.200000 (  0.261347)
index_solr add one more page to a parent with 10000 existing children  0.870000   0.110000   0.980000 (  1.086597)
       user     system      total        real
indexing_persister create 10000 children 33.320000   7.160000  40.480000 (144.817518)
indexing_persister save parent with 10000 children  1.230000   0.180000   1.410000 (  1.579009)
indexing_persister reload parent with 10000 children  0.030000   0.000000   0.030000 (  0.033946)
indexing_persister add one more page to a parent with 10000 existing children  1.490000   0.170000   1.660000 (  1.765953)
```

After:

```
Running via Spring preloader in process 24550
       user     system      total        real
postgres create 10000 children  3.670000   2.360000   6.030000 (  6.293269)
postgres save parent with 10000 children  0.470000   0.010000   0.480000 (  0.519934)
postgres reload parent with 10000 children  0.050000   0.000000   0.050000 (  0.053804)
postgres add one more page to a parent with 10000 existing children  0.810000   0.010000   0.820000 (  0.816545)
       user     system      total        real
memory create 10000 children  0.140000   0.000000   0.140000 (  0.144932)
memory save parent with 10000 children  0.000000   0.000000   0.000000 (  0.000069)
memory reload parent with 10000 children  0.000000   0.000000   0.000000 (  0.000703)
memory add one more page to a parent with 10000 existing children  0.010000   0.000000   0.010000 (  0.005127)
       user     system      total        real
index_solr create 10000 children  1.030000   0.050000   1.080000 (  1.185742)
index_solr save parent with 10000 children  1.070000   0.200000   1.270000 (  1.371235)
index_solr reload parent with 10000 children  0.110000   0.020000   0.130000 (  0.185160)
index_solr add one more page to a parent with 10000 existing children  0.850000   0.180000   1.030000 (  1.130345)
       user     system      total        real
indexing_persister create 10000 children  4.460000   2.260000   6.720000 (  7.010740)
indexing_persister save parent with 10000 children  1.280000   0.200000   1.480000 (  1.619743)
indexing_persister reload parent with 10000 children  0.030000   0.010000   0.040000 (  0.034978)
indexing_persister add one more page to a parent with 10000 existing children  1.440000   0.170000   1.610000 (  1.714819)
```