### PR TITLE
Support DateTime

### DIFF
--- a/app/persistence/valkyrie/persistence/postgres/orm/resource.rb
+++ b/app/persistence/valkyrie/persistence/postgres/orm/resource.rb
@@ -50,6 +50,19 @@ module Valkyrie::Persistence::Postgres
           end
         end
 
+        class DateValue < ValueMapper
+          PostgresValue.register(self)
+          def self.handles?(value)
+            DateTime.parse(value).in_time_zone
+          rescue
+            false
+          end
+
+          def result
+            DateTime.parse(value).in_time_zone
+          end
+        end
+
         class EnumeratorValue < ValueMapper
           PostgresValue.register(self)
           def self.handles?(value)

--- a/app/persistence/valkyrie/persistence/solr/mapper.rb
+++ b/app/persistence/valkyrie/persistence/solr/mapper.rb
@@ -115,6 +115,17 @@ module Valkyrie::Persistence::Solr
         end
       end
 
+      class DateTimePropertyValue < ValueMapper
+        SolrMapperValue.register(self)
+        def self.handles?(value)
+          value.is_a?(Property) && (value.value.is_a?(Time) || value.value.is_a?(DateTime))
+        end
+
+        def result
+          calling_mapper.for(Property.new(value.key, "datetime-#{JSON.parse(value.value.to_json)}")).result
+        end
+      end
+
       class SharedStringPropertyValue < ValueMapper
         SolrMapperValue.register(self)
         def self.handles?(value)

--- a/app/persistence/valkyrie/persistence/solr/resource_factory.rb
+++ b/app/persistence/valkyrie/persistence/solr/resource_factory.rb
@@ -125,6 +125,19 @@ module Valkyrie::Persistence::Solr
           Valkyrie::ID.new(value.gsub(/^id-/, ''))
         end
       end
+
+      class DateTimeValue < ValueMapper
+        SolrValue.register(self)
+        def self.handles?(value)
+          DateTime.parse(value.gsub(/^datetime-/, '')).in_time_zone
+        rescue
+          false
+        end
+
+        def result
+          DateTime.parse(value.gsub(/^datetime-/, '')).in_time_zone
+        end
+      end
     end
   end
 end

--- a/config/initializers/time_encoding_precision.rb
+++ b/config/initializers/time_encoding_precision.rb
@@ -1,0 +1,2 @@
+# frozen_string_literal: true
+ActiveSupport::JSON::Encoding.time_precision = 6

--- a/lib/valkyrie/specs/shared_specs/persister.rb
+++ b/lib/valkyrie/specs/shared_specs/persister.rb
@@ -43,6 +43,15 @@ RSpec.shared_examples 'a Valkyrie::Persister' do
     expect([shared_title.id, "test"]).to contain_exactly(*reloaded.title)
   end
 
+  it "can store datetimes" do
+    time = DateTime.current
+    book = persister.save(model: resource_class.new(title: [time]))
+
+    reloaded = query_service.find_by(id: book.id)
+
+    expect(reloaded.title).to contain_exactly time
+  end
+
   it "can order members" do
     book = persister.save(model: resource_class.new)
     book2 = persister.save(model: resource_class.new)


### PR DESCRIPTION
I'm not super happy with this - the Fedora adapter actually doesn't pass
the test if you give it an ActiveSupport::TimeWithZone instead. Plus there's the nasty JSON initializer.