### PR TITLE
Remove dead ActiveFedora::ResourceFactory code.

### DIFF
--- a/lib/valkyrie/persistence/active_fedora/resource_factory.rb
+++ b/lib/valkyrie/persistence/active_fedora/resource_factory.rb
@@ -63,11 +63,6 @@ module Valkyrie::Persistence::ActiveFedora
             solr_hit.fetch("file_identifiers_ssim", []).map { |x| Valkyrie::ID.new(x) }
           end
 
-          def method_missing(meth_name, *args)
-            return super if args.present?
-            solr_hit["#{meth_name}_ssim"] || super
-          end
-
           private
 
             def attribute_hash


### PR DESCRIPTION
There was a thought at one point this was necessary for SolrFaker to
work, but now everything just uses #attributes.