### PR TITLE
Spec cleanup

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
   TargetRubyVersion: 2.3
   Exclude:
     - 'bin/*'
+    - 'db/schema.rb'
     - 'config/deploy.rb'
     - 'vendor/**/*'
 Style/FileName:

--- a/lib/valkyrie/specs/shared_specs/persister.rb
+++ b/lib/valkyrie/specs/shared_specs/persister.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 RSpec.shared_examples 'a Valkyrie::Persister' do
   before do
-    raise 'persister must be set with `let(:persister)`' unless
-      defined? persister
+    raise 'persister must be set with `let(:persister)`' unless defined? persister
     class CustomResource < Valkyrie::Model
       attribute :id, Valkyrie::Types::ID.optional
       attribute :title
@@ -12,9 +11,10 @@ RSpec.shared_examples 'a Valkyrie::Persister' do
   after do
     Object.send(:remove_const, :CustomResource)
   end
+
   subject { persister }
-  let(:resource) { CustomResource.new }
   let(:resource_class) { CustomResource }
+  let(:resource) { resource_class.new }
   let(:query_service) { persister.adapter.query_service }
 
   it { is_expected.to respond_to(:save).with_keywords(:model) }
@@ -28,7 +28,6 @@ RSpec.shared_examples 'a Valkyrie::Persister' do
     book = persister.save(model: resource_class.new)
     book.title = "test"
     book = persister.save(model: book)
-
     expect(book.created_at).not_to be_blank
     expect(book.updated_at).not_to be_blank
     expect(book.created_at).not_to be_kind_of Array
@@ -37,66 +36,55 @@ RSpec.shared_examples 'a Valkyrie::Persister' do
 
   it "can handle language-typed RDF properties" do
     book = persister.save(model: resource_class.new(title: ["Test1", RDF::Literal.new("Test", language: :fr)]))
-
     reloaded = query_service.find_by(id: book.id)
-
     expect(reloaded.title).to contain_exactly "Test1", RDF::Literal.new("Test", language: :fr)
   end
 
   it "can store Valkyrie::Ids" do
     shared_title = persister.save(model: resource_class.new(id: "test"))
     book = persister.save(model: resource_class.new(title: [shared_title.id, Valkyrie::ID.new("adapter://1"), "test"]))
-
     reloaded = query_service.find_by(id: book.id)
-
-    expect(reloaded.title).to contain_exactly shared_title.id, Valkyrie::ID.new("adapter://1"), "test"
+    expect(reloaded.title).to contain_exactly(shared_title.id, Valkyrie::ID.new("adapter://1"), "test")
     expect([shared_title.id, Valkyrie::ID.new("adapter://1"), "test"]).to contain_exactly(*reloaded.title)
   end
 
   it "can store ::RDF::URIs" do
     book = persister.save(model: resource_class.new(title: [::RDF::URI("http://test.com")]))
-
     reloaded = query_service.find_by(id: book.id)
-
     expect(reloaded.title).to contain_exactly RDF::URI("http://test.com")
   end
 
   it "can store integers" do
     book = persister.save(model: resource_class.new(title: [1]))
-
     reloaded = query_service.find_by(id: book.id)
-
     expect(reloaded.title).to contain_exactly 1
   end
 
-  it "can order members" do
-    book = persister.save(model: resource_class.new)
-    book2 = persister.save(model: resource_class.new)
-    book3 = persister.save(model: resource_class.new)
-    parent = persister.save(model: resource_class.new(member_ids: [book2.id, book.id]))
-    parent.member_ids = parent.member_ids + [book3.id]
-    parent = persister.save(model: parent)
+  context "parent tests" do
+    let(:book) { persister.save(model: resource_class.new) }
+    let(:book2) { persister.save(model: resource_class.new) }
 
-    reloaded = query_service.find_by(id: parent.id)
-    expect(reloaded.member_ids).to eq [book2.id, book.id, book3.id]
-  end
+    it "can order members" do
+      book3 = persister.save(model: resource_class.new)
+      parent = persister.save(model: resource_class.new(member_ids: [book2.id, book.id]))
+      parent.member_ids = parent.member_ids + [book3.id]
+      parent = persister.save(model: parent)
+      reloaded = query_service.find_by(id: parent.id)
+      expect(reloaded.member_ids).to eq [book2.id, book.id, book3.id]
+    end
 
-  it "can remove members" do
-    book = persister.save(model: resource_class.new)
-    book2 = persister.save(model: resource_class.new)
-    parent = persister.save(model: resource_class.new(member_ids: [book2.id, book.id]))
-    parent.member_ids = parent.member_ids - [book2.id]
-    parent = persister.save(model: parent)
-
-    expect(parent.member_ids).to eq [book.id]
+    it "can remove members" do
+      parent = persister.save(model: resource_class.new(member_ids: [book2.id, book.id]))
+      parent.member_ids = parent.member_ids - [book2.id]
+      parent = persister.save(model: parent)
+      expect(parent.member_ids).to eq [book.id]
+    end
   end
 
   it "doesn't override a resource that already has an ID" do
     book = persister.save(model: resource_class.new)
     id = book.id
-
     output = persister.save(model: book)
-
     expect(output.id).to eq id
   end
 
@@ -106,7 +94,6 @@ RSpec.shared_examples 'a Valkyrie::Persister' do
 
   it "can find that resource again" do
     id = persister.save(model: resource).id
-
     expect(persister.adapter.query_service.find_by(id: id)).to be_kind_of resource_class
   end
 
@@ -114,31 +101,20 @@ RSpec.shared_examples 'a Valkyrie::Persister' do
     persisted = persister.save(model: resource)
     query_service = persister.adapter.query_service
     persister.delete(model: persisted)
-
     expect { query_service.find_by(id: persisted.id) }.to raise_error ::Persister::ObjectNotFoundError
   end
 
   context "when wrapped with a form object" do
-    before do
-      class ResourceForm < Valkyrie::Form
-        self.fields = [:title, :member_ids]
-      end
-    end
-    after do
-      Object.send(:remove_const, :ResourceForm)
-    end
-    it "works" do
-      form = ResourceForm.new(CustomResource.new)
+    let(:myclass) { Class.new(Valkyrie::Form) { self.fields = [:title, :member_ids] } }
+    let(:form) { myclass.new(resource_class.new) }
 
+    it "works" do
       expect(persister.save(model: form).id).not_to be_blank
     end
     it "doesn't return a form object" do
-      form = ResourceForm.new(CustomResource.new)
-
       persisted = persister.save(model: form)
       reloaded = query_service.find_by(id: persisted.id)
-
-      expect(reloaded).to be_kind_of(CustomResource)
+      expect(reloaded).to be_kind_of(resource_class)
     end
   end
 end

--- a/spec/valkyrie/persistence/solr/persister_spec.rb
+++ b/spec/valkyrie/persistence/solr/persister_spec.rb
@@ -3,43 +3,41 @@ require 'rails_helper'
 require 'valkyrie/specs/shared_specs'
 
 RSpec.describe Valkyrie::Persistence::Solr::Persister do
-  let(:persister) { Valkyrie::Persistence::Solr::Adapter.new(connection: Blacklight.default_index.connection).persister }
+  let(:connection) { Blacklight.default_index.connection }
+  let(:persister) { Valkyrie::Persistence::Solr::Adapter.new(connection: connection).persister }
+
   it_behaves_like "a Valkyrie::Persister"
 
   context "when given additional persisters" do
-    let(:adapter) { Valkyrie::Persistence::Solr::Adapter.new(connection: Blacklight.default_index.connection, resource_indexer: indexer) }
-    let(:indexer) { ResourceIndexer }
-    before do
-      class ResourceIndexer
+    let(:adapter) { Valkyrie::Persistence::Solr::Adapter.new(connection: connection, resource_indexer: indexer_class) }
+    let(:resource_class) do
+      Class.new(Valkyrie::Model) do
+        attribute :id, String
+        attribute :title, Valkyrie::Types::Set
+        attribute :other_title, Valkyrie::Types::Set
+      end
+    end
+    let(:indexer_class) do
+      Class.new do
         attr_reader :resource
         def initialize(resource:)
           @resource = resource
         end
 
         def to_solr
-          {
-            "combined_title_ssim" => resource.title + resource.other_title
-          }
+          { "combined_title_ssim" => resource.title + resource.other_title }
         end
       end
-      class Resource < Valkyrie::Model
-        attribute :id, String
-        attribute :title, Valkyrie::Types::Set
-        attribute :other_title, Valkyrie::Types::Set
-      end
     end
-    after do
-      Object.send(:remove_const, :ResourceIndexer)
-      Object.send(:remove_const, :Resource)
-    end
+
     it "can add custom indexing" do
-      b = Resource.new(title: ["Test"], other_title: ["Author"])
+      b = resource_class.new(title: ["Test"], other_title: ["Author"])
       expect(adapter.resource_factory.from_model(b)["combined_title_ssim"]).to eq ["Test", "Author"]
     end
   end
 
   context "when told to index a really long string" do
-    let(:adapter) { Valkyrie::Persistence::Solr::Adapter.new(connection: Blacklight.default_index.connection) }
+    let(:adapter) { Valkyrie::Persistence::Solr::Adapter.new(connection: connection) }
     it "works" do
       b = Book.new(title: "a" * 100_000)
       expect { adapter.persister.save(model: b) }.not_to raise_error


### PR DESCRIPTION
Mainly around using anonymous classes where possible instead of inline class declarations and follow-up undefinition of them.

A couple points where I used `let` for common constructions instead of repeated variable assignments.  I think this helps make the tests clearer for the part they are testing vs. what is setup.