### PR TITLE
Add BufferedPersister.

### DIFF
--- a/valkyrie/lib/valkyrie/persistence.rb
+++ b/valkyrie/lib/valkyrie/persistence.rb
@@ -5,6 +5,7 @@ module Valkyrie
     require 'valkyrie/persistence/postgres'
     require 'valkyrie/persistence/solr'
     require 'valkyrie/persistence/composite_persister'
+    require 'valkyrie/persistence/buffered_persister'
     class ObjectNotFoundError < StandardError
     end
   end

--- a/valkyrie/lib/valkyrie/persistence/buffered_persister.rb
+++ b/valkyrie/lib/valkyrie/persistence/buffered_persister.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+module Valkyrie::Persistence
+  class BufferedPersister
+    attr_reader :persister
+    delegate :adapter, to: :persister
+    def initialize(persister)
+      @persister = persister
+    end
+
+    def save(model:)
+      persister.save(model: model)
+    end
+
+    def save_all(models:)
+      persister.save_all(models: models)
+    end
+
+    def delete(model:)
+      persister.delete(model: model)
+    end
+
+    def with_buffer
+      memory_buffer = Valkyrie::Persistence::Memory::Adapter.new
+      yield [Valkyrie::Persistence::CompositePersister.new(self, memory_buffer.persister), memory_buffer]
+    end
+  end
+end

--- a/valkyrie/spec/valkyrie/persistence/buffered_persister_spec.rb
+++ b/valkyrie/spec/valkyrie/persistence/buffered_persister_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'valkyrie/specs/shared_specs'
+
+RSpec.describe Valkyrie::Persistence::BufferedPersister do
+  let(:persister) do
+    described_class.new(
+      Valkyrie::Persistence::Memory::Adapter.new.persister
+    )
+  end
+  before do
+    class Resource < Valkyrie::Model
+      attribute :id, Valkyrie::Types::ID.optional
+      attribute :title
+      attribute :member_ids
+      attribute :nested_resource
+    end
+  end
+  after do
+    Object.send(:remove_const, :Resource)
+  end
+  it_behaves_like "a Valkyrie::Persister"
+  describe "#with_buffer" do
+    it "can buffer a session into a memory adapter" do
+      buffer = nil
+      persister.with_buffer do |persister, memory_buffer|
+        persister.save(model: Resource.new)
+        buffer = memory_buffer
+      end
+      expect(buffer.query_service.find_all.length).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
Allows for decorating on the ability to buffer a set of actions into a
memory persister. Really useful for doing a bunch of actions and then
indexing later.

Closes #98 

I wasn't going to make this a decorator originally, but seeing the exact same code split out amongst all the persisters seemed problematic. I didn't want to go down the road of a parent class yet, either.