### PR TITLE
Update to database_cleaner 1.6.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,7 +144,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     daemons (1.2.4)
-    database_cleaner (1.5.3)
+    database_cleaner (1.6.1)
     debug_inspector (0.0.2)
     declarative (0.0.9)
     declarative-builder (0.1.0)


### PR DESCRIPTION
Fixes #106 

Updating `database_cleaner` to 1.6.1 fixes the following deprecation warning:

`DEPRECATION WARNING: schema_migrations_table_name is deprecated and will be removed from Rails 5.2`

See: http://databasecleaner.github.io/2017/05/04/v1-6-0-is-out/