### PR TITLE
add .byebug_history to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 /fcrepo4-test-data
 /fcrepo4-dev-data
 /valkyrie/tmp/
+.byebug_history


### PR DESCRIPTION
For those who might use `byebug` over `binding.pry` for whatever reason.