### PR TITLE
Add multiple image format support for ImageDerivativeService

### DIFF
--- a/app/derivative_services/image_derivative_service.rb
+++ b/app/derivative_services/image_derivative_service.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class ImageDerivativeService
   class Factory
     attr_reader :form_persister, :image_config, :use
@@ -85,7 +86,15 @@ class ImageDerivativeService
     @temporary_file ||= Tempfile.new
   end
 
+  ALLOWABLE_FORMATS = [
+    'image/bmp',
+    'image/gif',
+    'image/jpeg',
+    'image/png',
+    'image/tiff'
+  ].freeze
+
   def valid?
-    mime_type.include?("image/tiff")
+    ALLOWABLE_FORMATS.include?(mime_type.first)
   end
 end

--- a/spec/derivative_services/image_derivative_service_spec.rb
+++ b/spec/derivative_services/image_derivative_service_spec.rb
@@ -24,6 +24,23 @@ RSpec.describe ImageDerivativeService do
   let(:valid_model) { book_members.first }
   let(:valid_form) { DynamicFormClass.new.new(valid_model) }
 
+  describe '#valid?' do
+    subject(:valid_file) { derivative_service.new(valid_form) }
+
+    context 'when given a valid mime_type' do
+      it { is_expected.to be_valid }
+    end
+
+    context 'when given an invalid mime_type' do
+      it 'does not validate' do
+        # rubocop:disable RSpec/SubjectStub
+        allow(valid_file).to receive(:mime_type).and_return('image/invalid')
+        # rubocop:enable RSpec/SubjectStub
+        is_expected.not_to be_valid
+      end
+    end
+  end
+
   it "creates a thumbnail and attaches it to the fileset" do
     derivative_service.new(valid_form).create_derivatives
 


### PR DESCRIPTION
Fixes #132 

Adds ImageDerivativeService support for the following formats:
```
image/gif
image/jpeg
image/png
image/tiff
```
Includes tests for valid and invalid mime_types for `ImageDerivativeService#valid?`