### PR TITLE
[WIP] Add checksum to FileCharacterizationService

### DIFF
--- a/app/file_characterization_services/tika_file_characterization_service.rb
+++ b/app/file_characterization_services/tika_file_characterization_service.rb
@@ -21,10 +21,16 @@ class TikaFileCharacterizationService
   #   Valkyrie::FileCharacterizationService.for(file_node, persister).characterize(save: false)
   def characterize(save: true)
     result = JSON.parse(json_output).last
-    @file_characterization_attributes = FileCharacterizationAttributes.new(width: result['tiff:ImageWidth'], height: result['tiff:ImageLength'], mime_type: result['Content-Type'])
+    @file_characterization_attributes = FileCharacterizationAttributes.new(width: result['tiff:ImageWidth'], height: result['tiff:ImageLength'], mime_type: result['Content-Type'], checksum: checksum)
     @file_node = @file_node.new(@file_characterization_attributes.to_h)
     @persister.save(model: @file_node) if save
     @file_node
+  end
+
+  # Provides the SHA256 hexdigest string
+  # @return String
+  def checksum
+    Digest::SHA256.file(filename).hexdigest
   end
 
   def json_output
@@ -52,5 +58,6 @@ class TikaFileCharacterizationService
     attribute :width, Valkyrie::Types::Int
     attribute :height, Valkyrie::Types::Int
     attribute :mime_type, Valkyrie::Types::String
+    attribute :checksum, Valkyrie::Types::String
   end
 end

--- a/app/models/file_node.rb
+++ b/app/models/file_node.rb
@@ -6,6 +6,7 @@ class FileNode < Valkyrie::Model
   attribute :mime_type, Valkyrie::Types::Set
   attribute :height, Valkyrie::Types::Set
   attribute :width, Valkyrie::Types::Set
+  attribute :checksum, Valkyrie::Types::Set
   attribute :original_filename, Valkyrie::Types::Set
   attribute :file_identifiers, Valkyrie::Types::Set
   attribute :use, Valkyrie::Types::Set

--- a/config/initializers/valkyrie.rb
+++ b/config/initializers/valkyrie.rb
@@ -45,6 +45,8 @@ Rails.application.config.to_prepare do
     :indexing_persister
   )
 
+  # ImageDerivativeService needs its own change_set_persister because the
+  # derivatives may not be in the primary metadata/file storage.
   Valkyrie::DerivativeService.services << ImageDerivativeService::Factory.new(
     change_set_persister: ChangeSetPersister.new(
       metadata_adapter: Valkyrie::MetadataAdapter.find(:indexing_persister),

--- a/lib/valkyrie/persistence/active_fedora/orm/resource.rb
+++ b/lib/valkyrie/persistence/active_fedora/orm/resource.rb
@@ -21,6 +21,7 @@ module Valkyrie::Persistence::ActiveFedora::ORM
     property :nested_resource, predicate: ::RDF::URI("http://example.com/nested_resource")
     property :height, predicate: ::RDF::URI("http://example.com/height")
     property :width, predicate: ::RDF::URI("http://example.com/height")
+    property :checksum, predicate: ::RDF::URI("http://example.com/checksum")
   end
   class NestedResource < ActiveTriples::Resource
     def initialize(uri = RDF::Node.new, _parent = ActiveTriples::Resource.new)

--- a/spec/file_characterization_services/tika_file_characterization_service_spec.rb
+++ b/spec/file_characterization_services/tika_file_characterization_service_spec.rb
@@ -25,6 +25,12 @@ RSpec.describe TikaFileCharacterizationService do
   let(:valid_file_set) { book_members.first }
   let(:valid_file_node) { adapter.query_service.find_members(model: valid_file_set).first }
 
+  before do
+    output = '547c81b080eb2d7c09e363a670c46960ac15a6821033263867dd59a31376509c'
+    ruby_mock = instance_double(Digest::SHA256, hexdigest: output)
+    allow(Digest::SHA256).to receive(:hexdigest).and_return(ruby_mock)
+  end
+
   it 'characterizes a sample file' do
     Valkyrie::FileCharacterizationService.for(file_node: valid_file_node, persister: persister).characterize
   end
@@ -52,7 +58,7 @@ RSpec.describe TikaFileCharacterizationService do
   it 'does not save to the persister when characterize is called with save false' do
     allow(persister).to receive(:save).and_return(valid_file_node)
     Valkyrie::FileCharacterizationService.for(file_node: valid_file_node, persister: persister).characterize(save: false)
-    expect(persister).not_to have_received(:save).with(model: valid_file_node)
+    expect(persister).not_to have_received(:save)
   end
 
   it 'sets the mime_type for a file_node on characterize' do
@@ -60,5 +66,12 @@ RSpec.describe TikaFileCharacterizationService do
     t_file_node.mime_type = nil
     new_file_node = Valkyrie::FileCharacterizationService.for(file_node: t_file_node, persister: persister).characterize(save: false)
     expect(new_file_node.mime_type).not_to be_empty
+  end
+
+  it 'sets the checksum for a file_node on characterize' do
+    t_file_node = valid_file_node
+    t_file_node.checksum = nil
+    new_file_node = Valkyrie::FileCharacterizationService.for(file_node: t_file_node, persister: persister).characterize(save: false)
+    expect(new_file_node.checksum).not_to be_empty
   end
 end

--- a/valkyrie/lib/valkyrie/file_characterization_service.rb
+++ b/valkyrie/lib/valkyrie/file_characterization_service.rb
@@ -18,7 +18,7 @@ module Valkyrie
         new(file_node: file_node, persister: persister)
     end
     attr_reader :file_node, :persister
-    delegate :mime_type, :height, :width, to: :file_node
+    delegate :mime_type, :height, :width, :checksum, to: :file_node
     def initialize(file_node:, persister:)
       @file_node = file_node
       @persister = persister

--- a/valkyrie/spec/valkyrie/file_characterization_service_spec.rb
+++ b/valkyrie/spec/valkyrie/file_characterization_service_spec.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 require 'valkyrie/specs/shared_specs'
 
 RSpec.describe Valkyrie::FileCharacterizationService do
-  it_behaves_like "a Valkyrie::FileCharacterizationService"
+  it_behaves_like 'a Valkyrie::FileCharacterizationService'
   let(:valid_file_node) { FileNode.new }
   let(:file_characterization_service) { described_class }
   let(:persister) { Valkyrie::Persistence::Memory::MetadataAdapter.new.persister }
@@ -13,13 +14,14 @@ RSpec.describe Valkyrie::FileCharacterizationService do
       attribute :mime_type, Valkyrie::Types::Set
       attribute :height, Valkyrie::Types::Set
       attribute :width, Valkyrie::Types::Set
+      attribute :checksum, Valkyrie::Types::Set
     end
   end
   after do
     Object.send(:remove_const, :FileNode)
   end
 
-  it "can have a registered service" do
+  it 'can have a registered service' do
     new_service = instance_double(described_class, valid?: true)
     service_class = class_double(described_class, new: new_service)
     described_class.services << service_class


### PR DESCRIPTION
Refs: #163 

- Sets SHA256 hexdigest `checksum` attribute in `TikaFileCharacterizationService`
- Adds `checksum` property to `Valkyrie::Persistence::ActiveFedora::ORM::Schema`