### PR TITLE
Use iso8601 method

### DIFF
--- a/valkyrie/lib/valkyrie/persistence/postgres/orm/resource.rb
+++ b/valkyrie/lib/valkyrie/persistence/postgres/orm/resource.rb
@@ -79,7 +79,7 @@ module Valkyrie::Persistence::Postgres
         class DateValue < ::Valkyrie::ValueMapper
           PostgresValue.register(self)
           def self.handles?(value)
-            DateTime.parse(value).utc
+            DateTime.iso8601(value).utc
           rescue
             false
           end

--- a/valkyrie/lib/valkyrie/persistence/solr/resource_factory.rb
+++ b/valkyrie/lib/valkyrie/persistence/solr/resource_factory.rb
@@ -194,7 +194,7 @@ module Valkyrie::Persistence::Solr
       class DateTimeValue < ::Valkyrie::ValueMapper
         SolrValue.register(self)
         def self.handles?(value)
-          DateTime.parse(value.gsub(/^datetime-/, '')).utc
+          DateTime.iso8601(value.gsub(/^datetime-/, '')).utc
         rescue
           false
         end


### PR DESCRIPTION
Solr/Postgres were converting non-dates into dates because they'd make
it through DateTime.parse