### PR TITLE
Update Fedora and Solr configurations

### DIFF
--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -2,17 +2,17 @@
 # each environment can have a jetty_path with absolute or relative
 # (to app root) path to a jetty/solr install. This is used
 # by the rake tasks that start up solr automatically for testing
-# and by rake solr:marc:index.  
+# and by rake solr:marc:index.
 #
 # jetty_path is not used by a running Blacklight application
 # at all. In general you do NOT need to deploy solr in Jetty, you can deploy it
-# however you want.  
+# however you want.
 # jetty_path is only required for rake tasks that need to know
-# how to start up solr, generally for automated testing. 
+# how to start up solr, generally for automated testing.
 
 development:
   adapter: solr
-  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/blacklight-core" %>
+  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV['DEVELOPMENT_JETTY_PORT'] || 8983}/solr/blacklight-core" %>
 test: &test
   adapter: solr
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV['TEST_JETTY_PORT'] || 8984}/solr/blacklight-core-test" %>

--- a/config/fedora.yml
+++ b/config/fedora.yml
@@ -1,10 +1,10 @@
 development:
   user: fedoraAdmin
   password: fedoraAdmin
-  url: http://localhost:8986/rest
+  url: http://localhost:<%= ENV['FCREPO_DEVELOPMENT_PORT'] || 8986 %>/rest
   base_path: /dev
 test:
   user: fedoraAdmin
   password: fedoraAdmin
-  url: http://localhost:8988/rest
+  url: http://localhost:<%= ENV['FCREPO_TEST_PORT'] || 8988 %>/rest
   base_path: /test

--- a/config/solr.yml
+++ b/config/solr.yml
@@ -1,8 +1,8 @@
 # This is a sample config file that points to a solr server for each environment
 development:
-  url: http://localhost:8987/solr/hydra-dev
+  url: <%= "http://localhost:#{ENV['SOLR_DEVELOPMENT_PORT'] || 8987}/solr/hydra-dev" %>
 test:
-  url: <%= "http://localhost:#{ENV['TEST_JETTY_PORT'] || 8985}/solr/hydra-test" %>
+  url: <%= "http://localhost:#{ENV['SOLR_TEST_PORT'] || 8985}/solr/hydra-test" %>
 production: &production
   url: <%= ENV["PLUM_SOLR_URL"] %>
 staging:


### PR DESCRIPTION
Fedora was being downloaded to temp space, which is deleted during
reboot, and the ports for the Fedora and two Solr instances weren't
changeable if local usage required it.

Fedora and Solr zip files are downloaded to the tmp directory where they
can remain until deleted. Also, each port for each Solr and Fedora
instance can be configured using an environment variable, should you
want to run Solr and Fedora independently on your local system.