### PR TITLE
In memory adapter fails when all objects do not respond to property

### DIFF
--- a/valkyrie/lib/valkyrie/persistence/memory/query_service.rb
+++ b/valkyrie/lib/valkyrie/persistence/memory/query_service.rb
@@ -60,7 +60,11 @@ module Valkyrie::Persistence::Memory
     #   in order.
     def find_inverse_references_by(resource:, property:)
       find_all.select do |obj|
-        Array.wrap(obj[property]).include?(resource.id)
+        begin
+          Array.wrap(obj[property]).include?(resource.id)
+        rescue
+          false
+        end
       end
     end
 

--- a/valkyrie/lib/valkyrie/specs/shared_specs/queries.rb
+++ b/valkyrie/lib/valkyrie/specs/shared_specs/queries.rb
@@ -99,6 +99,7 @@ RSpec.shared_examples 'a Valkyrie query provider' do
       parent = persister.save(resource: resource_class.new)
       child = persister.save(resource: resource_class.new(a_member_of: [parent.id]))
       persister.save(resource: resource_class.new)
+      persister.save(resource: SecondResource.new)
 
       expect(query_service.find_inverse_references_by(resource: parent, property: :a_member_of).map(&:id).to_a).to eq [child.id]
     end


### PR DESCRIPTION
Adding an additional object to the shared spec to show off the issue with the in memory adapter
Rescuing the error the in memory adapter throws when all objects do not respond to the property in find_inverse_refernces_by