### PR TITLE
Extends Resources to exposed human-readable type names

### DIFF
--- a/valkyrie/lib/valkyrie/resource.rb
+++ b/valkyrie/lib/valkyrie/resource.rb
@@ -47,6 +47,14 @@ module Valkyrie
 
     delegate :model_name, to: :class
 
+    def self.human_readable_type
+      @_human_readable_type ||= name.demodulize.titleize
+    end
+
+    def self.human_readable_type=(val)
+      @_human_readable_type = val
+    end
+
     # @return [Hash] Hash of attributes
     def attributes
       to_h
@@ -86,6 +94,13 @@ module Valkyrie
     # @return [String]
     def to_s
       "#{self.class}: #{id}"
+    end
+
+    ##
+    # Provide a human readable name for the resource
+    # @return [String]
+    def human_readable_type
+      self.class.human_readable_type
     end
   end
 end

--- a/valkyrie/lib/valkyrie/specs/shared_specs/resource.rb
+++ b/valkyrie/lib/valkyrie/specs/shared_specs/resource.rb
@@ -49,4 +49,23 @@ RSpec.shared_examples 'a Valkyrie::Resource' do
       expect(resource.internal_resource).to eq resource_klass.to_s
     end
   end
+
+  describe "#human_readable_type" do
+    before do
+      class MyCustomResource < Valkyrie::Resource
+        attribute :id, Valkyrie::Types::ID.optional
+        attribute :title, Valkyrie::Types::Set
+      end
+    end
+
+    after do
+      Object.send(:remove_const, :MyCustomResource)
+    end
+
+    subject(:my_custom_resource) { MyCustomResource.new }
+
+    it "returns a human readable rendering of the resource class" do
+      expect(my_custom_resource.human_readable_type).to eq "My Custom Resource"
+    end
+  end
 end


### PR DESCRIPTION
Resolves #182 by extending Valkyrie resources with a method for generating human-readable type names