### PR TITLE
Show all objects that are a member_of a collection

### DIFF
--- a/app/controllers/concerns/catalog.rb
+++ b/app/controllers/concerns/catalog.rb
@@ -88,7 +88,6 @@ module Catalog
       config.add_show_field('member_ids_tesim', label: 'Member IDs')
       config.add_show_field('file_identifiers_tesim', label: 'File Identifiers')
       config.show.partials = config.show.partials.insert(1, :parent_breadcrumb)
-      config.show.partials = config.show.partials.insert(2, :children)
       config.add_facet_field 'author_ssim', label: 'Author'
     end
   end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -31,6 +31,10 @@ class SolrDocument
     QueryService.find_members(resource: Book.new(id: resource_id, member_ids: member_ids)).map(&:decorate)
   end
 
+  def children
+    QueryService.find_inverse_references_by(resource: Collection.new(id: resource_id), property: :a_member_of)
+  end
+
   def resource_id
     Valkyrie::ID.new(id.gsub(/^id-/, ''))
   end

--- a/app/services/query_service.rb
+++ b/app/services/query_service.rb
@@ -3,7 +3,7 @@ class QueryService
   class_attribute :metadata_adapter
   self.metadata_adapter = Valkyrie.config.metadata_adapter
   class << self
-    delegate :find_all, :find_by, :find_members, to: :default_adapter
+    delegate :find_all, :find_by, :find_members, :find_inverse_references_by, to: :default_adapter
 
     def default_adapter
       new(metadata_adapter: metadata_adapter)
@@ -11,7 +11,7 @@ class QueryService
   end
 
   attr_reader :metadata_adapter
-  delegate :find_all, :find_by, :find_members, to: :metadata_adapter_query_service
+  delegate :find_all, :find_by, :find_members, :find_inverse_references_by, to: :metadata_adapter_query_service
   def initialize(metadata_adapter:)
     @metadata_adapter = metadata_adapter
   end

--- a/app/views/catalog/_members_collection.html.erb
+++ b/app/views/catalog/_members_collection.html.erb
@@ -1,7 +1,7 @@
 <h2>Members</h2>
 <table class="table table-striped">
   <tbody>
-    <% @document.members.each do |child| %>
+    <% @document.children.each do |child| %>
       <tr>
         <td>
           <%= link_to child.title, solr_document_path(id: "id-#{child.id}") %>

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -30,4 +30,24 @@ RSpec.describe SolrDocument do
       end
     end
   end
+
+  describe "#children" do
+    context "when the collection has children" do
+      subject(:children) { solr_document.children }
+      let(:solr_document) { described_class.new(solr_hash) }
+      let(:solr_hash) { solr_adapter.resource_factory.from_resource(collection).to_h }
+      let(:collection) { Persister.save(resource: Collection.new) }
+      let(:child_book) { Persister.save(resource: Book.new(a_member_of: [collection.id])) }
+      let(:other_book) { Persister.save(resource: Book.new) }
+      before do
+        child_book
+        other_book
+      end
+
+      it "returns them" do
+        expect(children.count).to eq 1
+        expect(children.first.id).to eq child_book.id
+      end
+    end
+  end
 end

--- a/spec/views/catalog/_members_collection.html.erb_spec.rb
+++ b/spec/views/catalog/_members_collection.html.erb_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe "catalog/_children_collection.html.erb" do
-  let(:document) { instance_double(SolrDocument, resource: resource, members: [child]) }
+RSpec.describe "catalog/_members_collection.html.erb" do
+  let(:document) { instance_double(SolrDocument, resource: resource, children: [child]) }
   let(:resource) { persister.save(resource: Book.new(title: "Title")) }
   let(:persister) { Valkyrie.config.metadata_adapter.persister }
   let(:child) { persister.save(resource: Book.new(title: "Child", a_member_of: resource.id)).decorate }
@@ -13,7 +13,7 @@ RSpec.describe "catalog/_children_collection.html.erb" do
     render
   end
 
-  it "displays all members of the resource" do
+  it "displays all children of the resource" do
     expect(response).to have_link "Child"
     expect(response).not_to have_link "[\"Child\"]"
   end


### PR DESCRIPTION
add query to solr document to allow for finding a collection's children
Displaying the children as the members of a collection instead of a separate partial

fixes #199 