### PR TITLE
Only display book actions for books

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -42,4 +42,8 @@ class SolrDocument
   def resource
     @resource ||= QueryService.find_by(id: resource_id)
   end
+
+  def book?
+    resource.class == Book
+  end
 end

--- a/app/views/catalog/_admin_tools.html.erb
+++ b/app/views/catalog/_admin_tools.html.erb
@@ -9,24 +9,9 @@
         <%= link_to "Edit", polymorphic_path([:edit, document.resource]) %>
         <%= link_to "Delete", polymorphic_path([document.resource]), method: :delete %>
       </li>
-      <li>
-        <div class="btn-group">
-          <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            Add Child <span class="caret"></span>
-          </button>
-          <ul class="dropdown-menu">
-            <li>
-              <%= link_to "Add Book", book_append_book_path(id: document.resource_id) %>
-            </li>
-            <li>
-              <%= link_to "Add Page", page_append_book_path(id: document.resource_id) %>
-            </li>
-          </ul>
-        </div>
-      </li>
-      <li>
-        <%= link_to "File Manager", file_manager_book_path(id: document.resource_id) %>
-      </li>
+      <% if document.book? %>
+        <%= render 'book_admin_list_items', document: document %>
+      <% end %>
     </ul>
   </div>
 </div>

--- a/app/views/catalog/_book_admin_list_items.html.erb
+++ b/app/views/catalog/_book_admin_list_items.html.erb
@@ -1,0 +1,18 @@
+<li>
+  <div class="btn-group">
+    <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      Add Child <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu">
+      <li>
+        <%= link_to "Add Book", book_append_book_path(id: document.resource_id) %>
+      </li>
+      <li>
+        <%= link_to "Add Page", page_append_book_path(id: document.resource_id) %>
+      </li>
+    </ul>
+  </div>
+</li>
+<li>
+  <%= link_to "File Manager", file_manager_book_path(id: document.resource_id) %>
+</li>

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -50,4 +50,26 @@ RSpec.describe SolrDocument do
       end
     end
   end
+
+  describe '#book?' do
+    subject { solr_document.book? }
+    context "for a book" do
+      let(:book) { Persister.save(resource: Book.new) }
+      it { is_expected.to be_truthy }
+    end
+
+    context "for a collection" do
+      let(:solr_hash) { solr_adapter.resource_factory.from_resource(collection).to_h }
+      let(:collection) { Persister.save(resource: Collection.new) }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "for a page" do
+      let(:solr_hash) { solr_adapter.resource_factory.from_resource(page).to_h }
+      let(:page) { Persister.save(resource: Page.new) }
+
+      it { is_expected.to be_falsey }
+    end
+  end
 end

--- a/spec/views/catalog/_admin_tools.html.erb_spec.rb
+++ b/spec/views/catalog/_admin_tools.html.erb_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe "catalog/_admin_tools.html.erb" do
+  let(:persister) { Valkyrie.config.metadata_adapter.persister }
+
+  before do
+    render 'catalog/admin_tools', document: document
+  end
+
+  context 'for a book' do
+    let(:document) { instance_double(SolrDocument, resource: resource, book?: true, resource_id: 'abc123') }
+    let(:resource) { persister.save(resource: Book.new(title: "Title")) }
+
+    it "displays book tools" do
+      expect(response).to have_button "Add Child"
+      expect(response).to have_link "File Manager"
+    end
+  end
+
+  context 'for a collection' do
+    let(:document) { instance_double(SolrDocument, resource: resource, book?: false) }
+    let(:resource) { persister.save(resource: Collection.new(title: "Title")) }
+
+    it "does not display book tools" do
+      expect(response).not_to have_button "Add Child"
+      expect(response).not_to have_link "File Manager"
+    end
+  end
+end


### PR DESCRIPTION
Added a book? query to the solr document
Moved the book actions to a partial
Only display the book actions if the current resource is a book

This PR addresses the confusion I had with the Book buttons not working from the Collection page. 

Book Show page looks the same:
![screen shot 2017-09-06 at 1 07 09 pm](https://user-images.githubusercontent.com/1599081/30124952-e032f2ce-9304-11e7-8288-911f86d14fa0.png)

Collection Show page no longer has book actions:
![screen shot 2017-09-06 at 1 08 30 pm](https://user-images.githubusercontent.com/1599081/30124955-e1b62b20-9304-11e7-8636-8d666691d48f.png)


