### PR TITLE
Decorating children to display better

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -32,7 +32,7 @@ class SolrDocument
   end
 
   def children
-    QueryService.find_inverse_references_by(resource: Collection.new(id: resource_id), property: :a_member_of)
+    QueryService.find_inverse_references_by(resource: Collection.new(id: resource_id), property: :a_member_of).map(&:decorate)
   end
 
   def resource_id

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe SolrDocument do
       it "returns them" do
         expect(children.count).to eq 1
         expect(children.first.id).to eq child_book.id
+        expect(children.first.class).to eq BookDecorator
       end
     end
   end


### PR DESCRIPTION
Decorating the children allows them to be displayed nicely.  This was not needed when first was being called on the title in the solr document, but that has been removed.

View for master
![screen shot 2017-09-06 at 1 16 10 pm](https://user-images.githubusercontent.com/1599081/30125237-d22bd3b6-9305-11e7-8f53-d013e06be3de.png)

View after PR
![screen shot 2017-09-06 at 1 16 36 pm](https://user-images.githubusercontent.com/1599081/30125235-d0dbb88c-9305-11e7-9df9-51c6c06ca444.png)
