### PR TITLE
Custom predicates with Fedora resources, ref #198

### DIFF
--- a/valkyrie/.rubocop.yml
+++ b/valkyrie/.rubocop.yml
@@ -26,3 +26,5 @@ Style/PredicateName:
   Exclude:
     - "lib/valkyrie/resource.rb"
     - "lib/valkyrie/persistence/solr/queries/default_paginator.rb"
+Lint/UnusedMethodArgument:
+  AllowUnusedKeywordArguments: true

--- a/valkyrie/lib/valkyrie/persistence/fedora.rb
+++ b/valkyrie/lib/valkyrie/persistence/fedora.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 module Valkyrie::Persistence
   module Fedora
+    require 'valkyrie/persistence/fedora/permissive_schema'
     require 'valkyrie/persistence/fedora/metadata_adapter'
     require 'valkyrie/persistence/fedora/persister'
     require 'valkyrie/persistence/fedora/query_service'

--- a/valkyrie/lib/valkyrie/persistence/fedora/metadata_adapter.rb
+++ b/valkyrie/lib/valkyrie/persistence/fedora/metadata_adapter.rb
@@ -2,7 +2,7 @@
 module Valkyrie::Persistence::Fedora
   class MetadataAdapter
     attr_reader :connection, :base_path, :schema
-    def initialize(connection:, base_path: "/", schema: {})
+    def initialize(connection:, base_path: "/", schema: Valkyrie::Persistence::Fedora::PermissiveSchema.new)
       @connection = connection
       @base_path = base_path
       @schema = schema

--- a/valkyrie/lib/valkyrie/persistence/fedora/metadata_adapter.rb
+++ b/valkyrie/lib/valkyrie/persistence/fedora/metadata_adapter.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 module Valkyrie::Persistence::Fedora
   class MetadataAdapter
-    attr_reader :connection, :base_path
-    def initialize(connection:, base_path: "/")
+    attr_reader :connection, :base_path, :schema
+    def initialize(connection:, base_path: "/", schema: {})
       @connection = connection
       @base_path = base_path
+      @schema = schema
     end
 
     def query_service

--- a/valkyrie/lib/valkyrie/persistence/fedora/permissive_schema.rb
+++ b/valkyrie/lib/valkyrie/persistence/fedora/permissive_schema.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+module Valkyrie::Persistence::Fedora
+  class PermissiveSchema
+    attr_reader :schema
+    def initialize(schema = {})
+      @schema = schema
+    end
+
+    def predicate_for(resource:, property:)
+      schema.fetch(property, ::RDF::URI("http://example.com/predicate/#{property}"))
+    end
+  end
+end

--- a/valkyrie/lib/valkyrie/persistence/fedora/persister/model_converter.rb
+++ b/valkyrie/lib/valkyrie/persistence/fedora/persister/model_converter.rb
@@ -34,10 +34,6 @@ module Valkyrie::Persistence::Fedora
       class Property
         attr_reader :key, :value, :subject, :adapter
 
-        def self.to_uri(key)
-          RDF::URI.new("http://example.com/predicate/#{key}")
-        end
-
         def initialize(subject, key, value, adapter)
           @subject = subject
           @key = key
@@ -47,9 +43,13 @@ module Valkyrie::Persistence::Fedora
 
         def to_graph(graph = RDF::Graph.new)
           Array(value).each do |val|
-            graph << RDF::Statement.new(subject, self.class.to_uri(key), val)
+            graph << RDF::Statement.new(subject, predicate, val)
           end
           graph
+        end
+
+        def predicate
+          adapter.schema.fetch(key, ::RDF::URI("http://example.com/predicate/#{key}"))
         end
       end
 
@@ -124,7 +124,7 @@ module Valkyrie::Persistence::Fedora
         end
 
         def result
-          nested_graph << RDF::Statement.new(value.subject, Property.to_uri(value.key), subject_uri)
+          nested_graph << RDF::Statement.new(value.subject, value.predicate, subject_uri)
           GraphProperty.new(value.subject, value.key, nested_graph, value.adapter)
         end
 

--- a/valkyrie/spec/valkyrie/persistence/fedora/metadata_adapter_spec.rb
+++ b/valkyrie/spec/valkyrie/persistence/fedora/metadata_adapter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Valkyrie::Persistence::Fedora::MetadataAdapter do
 
   describe "#schema" do
     context "by default" do
-      specify { expect(adapter.schema).to eq({}) }
+      specify { expect(adapter.schema).to be_a Valkyrie::Persistence::Fedora::PermissiveSchema }
     end
 
     context "with a custom schema" do

--- a/valkyrie/spec/valkyrie/persistence/fedora/metadata_adapter_spec.rb
+++ b/valkyrie/spec/valkyrie/persistence/fedora/metadata_adapter_spec.rb
@@ -5,4 +5,15 @@ require 'valkyrie/specs/shared_specs'
 RSpec.describe Valkyrie::Persistence::Fedora::MetadataAdapter do
   let(:adapter) { described_class.new(connection: ::Ldp::Client.new("http://localhost:8988/rest"), base_path: "/test_fed") }
   it_behaves_like "a Valkyrie::MetadataAdapter"
+
+  describe "#schema" do
+    context "by default" do
+      specify { expect(adapter.schema).to eq({}) }
+    end
+
+    context "with a custom schema" do
+      let(:adapter) { described_class.new(connection: ::Ldp::Client.new("http://localhost:8988/rest"), base_path: "/test_fed", schema: "custom-schema") }
+      specify { expect(adapter.schema).to eq("custom-schema") }
+    end
+  end
 end

--- a/valkyrie/spec/valkyrie/persistence/fedora/persister/model_converter_spec.rb
+++ b/valkyrie/spec/valkyrie/persistence/fedora/persister/model_converter_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Valkyrie::Persistence::Fedora::Persister::ModelConverter do
   end
 
   context "with the default schema" do
-    let(:schema) { {} }
+    let(:schema) { Valkyrie::Persistence::Fedora::PermissiveSchema.new }
     let(:query)  { converter.convert.graph.query(predicate: RDF::URI("http://example.com/predicate/title")) }
 
     it "persists to Fedora using a fake predicate" do
@@ -35,7 +35,7 @@ RSpec.describe Valkyrie::Persistence::Fedora::Persister::ModelConverter do
   end
 
   context "with a defined schema" do
-    let(:schema) { { title: ::RDF::Vocab::DC.title } }
+    let(:schema) { Valkyrie::Persistence::Fedora::PermissiveSchema.new(title: ::RDF::Vocab::DC.title) }
     let(:query)  { converter.convert.graph.query(predicate: ::RDF::Vocab::DC.title) }
 
     it "persists to Fedora using the defined predicate" do

--- a/valkyrie/spec/valkyrie/persistence/fedora/persister/model_converter_spec.rb
+++ b/valkyrie/spec/valkyrie/persistence/fedora/persister/model_converter_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+RSpec.describe Valkyrie::Persistence::Fedora::Persister::ModelConverter do
+  let(:adapter) do
+    Valkyrie::Persistence::Fedora::MetadataAdapter.new(
+      connection: ::Ldp::Client.new("http://localhost:8988/rest"),
+      base_path: "test_fed",
+      schema: schema
+    )
+  end
+
+  let(:resource)  { SampleResource.new(title: "My Title") }
+  let(:converter) { described_class.new(resource: resource, adapter: adapter) }
+
+  before do
+    class SampleResource < Valkyrie::Resource
+      include Valkyrie::Resource::AccessControls
+      attribute :id, Valkyrie::Types::ID.optional
+      attribute :title
+    end
+  end
+
+  after do
+    Object.send(:remove_const, :SampleResource)
+  end
+
+  context "with the default schema" do
+    let(:schema) { {} }
+    let(:query)  { converter.convert.graph.query(predicate: RDF::URI("http://example.com/predicate/title")) }
+
+    it "persists to Fedora using a fake predicate" do
+      expect(query.first.object.to_s).to eq("My Title")
+    end
+  end
+
+  context "with a defined schema" do
+    let(:schema) { { title: ::RDF::Vocab::DC.title } }
+    let(:query)  { converter.convert.graph.query(predicate: ::RDF::Vocab::DC.title) }
+
+    it "persists to Fedora using the defined predicate" do
+      expect(query.first.object.to_s).to eq("My Title")
+    end
+  end
+end


### PR DESCRIPTION
Valkyrie was making up predicates when persisting attributes to Fedora.
We needed a way to provide a predicate for each attribute in the
resource.

Fedora's metadata adapter will accept a hash as a schema and use any
defined predicate for a given term. If no predicate is defined, the
current default one will be used.

Custom schemas must be provided when initializing the metadata adapter
in config/initializers/valkyrie.rb.