### PR TITLE
Create initial user accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ only be used for testing as it's not a persistent store.
    1. Start Solr and Fedora servers for testing with `rake server:test`
    1. Run the RSpec test suite with `rspec spec`
 1. To run the app in development mode for local usage:
+   1. Initial test accounts can be created with `rake db:seed`. In order to see the options
+      to create works you should sign in as `admin@example.com` with password `valkyrie`
    1. Start Solr and Fedora servers for development with `rake server:development`
    1. Bring up a Rails server with `rails s` or a console with `rails c`
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,3 +6,13 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+if Rails.env == 'development'
+  seed_file = Rails.root.join('config', 'role_map.yml')
+  config = YAML.load_file(seed_file)[Rails.env]
+
+  config.each do |_role, emails|
+    email = emails.first
+    password = 'valkyrie'
+    User.create!(email: email, password: password, password_confirmation: password) unless User.exists?(email: email)
+  end
+end


### PR DESCRIPTION
When setting up a development server rake db:seed will create initial accounts for testing. Uses the emails from role_map.yml.