### PR TITLE
Extending the Valkyrie.config Object with a "derivatives_adapter" method

### DIFF
--- a/valkyrie/config/valkyrie.yml
+++ b/valkyrie/config/valkyrie.yml
@@ -2,7 +2,9 @@
 test:
   metadata_adapter: test
   storage_adapter: test
+  derivatives_adapter: test
 development:
   metadata_adapter: test
   storage_adapter: test
+  derivatives_adapter: test
 production:

--- a/valkyrie/lib/valkyrie.rb
+++ b/valkyrie/lib/valkyrie.rb
@@ -74,6 +74,10 @@ module Valkyrie
     def storage_adapter
       Valkyrie::StorageAdapter.find(super.to_sym)
     end
+
+    def derivatives_adapter
+      Valkyrie::StorageAdapter.find(super.to_sym)
+    end
   end
 
   module_function :config, :logger, :logger=, :config_root_path, :environment

--- a/valkyrie/spec/valkyrie_spec.rb
+++ b/valkyrie/spec/valkyrie_spec.rb
@@ -33,6 +33,16 @@ describe Valkyrie do
 
     Valkyrie::StorageAdapter.storage_adapters = {}
   end
+
+  it "can have a configured derivatives adapter, which it looks up" do
+    derivatives_adapter = Valkyrie::Storage::Memory.new
+    Valkyrie::StorageAdapter.register(derivatives_adapter, :test)
+
+    expect(described_class.config.derivatives_adapter).to eq derivatives_adapter
+
+    Valkyrie::StorageAdapter.storage_adapters = {}
+  end
+
   context "when Rails is defined and configured" do
     it "uses that path" do
       allow(Rails).to receive(:root).and_return(ROOT_PATH)


### PR DESCRIPTION
Resolves #242 by extending the Valkyrie.config Object with a "derivatives_adapter" method