### PR TITLE
Removing useless local variable assignment

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,9 +24,6 @@ Naming/PredicateName:
 Style/MethodMissing:
   Exclude:
     - "lib/valkyrie/persistence/active_fedora/resource_factory.rb"
-Lint/UselessAssignment:
-  Exclude:
-    - 'lib/valkyrie/persistence/active_fedora/orm/resource.rb'
 Metrics/BlockLength:
   Exclude:
     - 'config/environments/**/*'

--- a/lib/valkyrie/persistence/active_fedora/orm/resource.rb
+++ b/lib/valkyrie/persistence/active_fedora/orm/resource.rb
@@ -54,7 +54,7 @@ module Valkyrie::Persistence::ActiveFedora::ORM
     accepts_nested_attributes_for :nested_resource
 
     def size=(size)
-      file_size = size
+      self.file_size = size
     end
 
     def size


### PR DESCRIPTION
Prior to this commit, Rubocop identified a useless assignment. I believe
the intention of the prior code was to set the `file_size` property of
the Resource. However, as written, the assignment was "useless" because
it set a local variable `file_size` (instead of the property).

I believe the fix is to prepend `self.` to the `file_size` assignment,
thus setting the expected property instead of the local variable.

```ruby
def size=(size)
  file_size = size
end
```

Related to d5528472f91d89617e64b1ef4185410a6be0b204