### PR TITLE
Removing Rubocop exception

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,9 +21,6 @@ Naming/PredicateName:
     - "lib/valkyrie/model.rb"
     - "lib/valkyrie/persistence/solr/queries/default_paginator.rb"
     - "lib/valkyrie/persistence/active_fedora/queries/default_paginator.rb"
-Style/MethodMissing:
-  Exclude:
-    - "lib/valkyrie/persistence/active_fedora/resource_factory.rb"
 Metrics/BlockLength:
   Exclude:
     - 'config/environments/**/*'


### PR DESCRIPTION
The exception no longer appears necessary.