### PR TITLE
Narrowing Rubocop exclusion path

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,8 +19,6 @@ Naming/FileName:
 Naming/PredicateName:
   Exclude:
     - "app/controllers/catalog_controller.rb"
-    - "lib/valkyrie/model.rb"
-    - "lib/valkyrie/persistence/solr/queries/default_paginator.rb"
     - "lib/valkyrie/persistence/active_fedora/queries/default_paginator.rb"
 Style/MethodMissing:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,8 @@ AllCops:
     - 'bin/*'
     - 'config/deploy.rb'
     - 'vendor/**/*'
-    - 'valkyrie/**/*'
+    - 'valkyrie/db/**/*'
+    - 'valkyrie/bin/**/*'
     - 'db/schema.rb'
 Naming/FileName:
   Enabled: true


### PR DESCRIPTION
Prior to this commit, all of the files in ./valkyrie were excluded.
Mercifully, many of those files don't have violations.