### PR TITLE
Fix query service caching for custom queries.

### DIFF
--- a/valkyrie/lib/valkyrie/persistence/fedora/metadata_adapter.rb
+++ b/valkyrie/lib/valkyrie/persistence/fedora/metadata_adapter.rb
@@ -9,7 +9,7 @@ module Valkyrie::Persistence::Fedora
     end
 
     def query_service
-      Valkyrie::Persistence::Fedora::QueryService.new(adapter: self)
+      @query_service ||= Valkyrie::Persistence::Fedora::QueryService.new(adapter: self)
     end
 
     def persister

--- a/valkyrie/lib/valkyrie/persistence/memory/metadata_adapter.rb
+++ b/valkyrie/lib/valkyrie/persistence/memory/metadata_adapter.rb
@@ -12,7 +12,7 @@ module Valkyrie::Persistence::Memory
     # @return [Valkyrie::Persistence::Memory::QueryService] A query service for
     #   this adapter.
     def query_service
-      Valkyrie::Persistence::Memory::QueryService.new(adapter: self)
+      @query_service ||= Valkyrie::Persistence::Memory::QueryService.new(adapter: self)
     end
 
     def cache

--- a/valkyrie/lib/valkyrie/persistence/postgres/metadata_adapter.rb
+++ b/valkyrie/lib/valkyrie/persistence/postgres/metadata_adapter.rb
@@ -10,7 +10,7 @@ module Valkyrie::Persistence::Postgres
 
     # @return [Class] {Valkyrie::Persistence::Postgres::QueryService}
     def query_service
-      Valkyrie::Persistence::Postgres::QueryService.new(adapter: self)
+      @query_service ||= Valkyrie::Persistence::Postgres::QueryService.new(adapter: self)
     end
 
     def resource_factory

--- a/valkyrie/lib/valkyrie/persistence/solr/metadata_adapter.rb
+++ b/valkyrie/lib/valkyrie/persistence/solr/metadata_adapter.rb
@@ -22,7 +22,10 @@ module Valkyrie::Persistence::Solr
     # @return [Valkyrie::Persistence::Solr::QueryService] The solr query
     #   service.
     def query_service
-      Valkyrie::Persistence::Solr::QueryService.new(connection: connection, resource_factory: resource_factory)
+      @query_service ||= Valkyrie::Persistence::Solr::QueryService.new(
+        connection: connection,
+        resource_factory: resource_factory
+      )
     end
 
     # @return [Valkyrie::Persistence::Solr::ResourceFactory] A resource factory

--- a/valkyrie/lib/valkyrie/specs/shared_specs/metadata_adapter.rb
+++ b/valkyrie/lib/valkyrie/specs/shared_specs/metadata_adapter.rb
@@ -7,4 +7,7 @@ RSpec.shared_examples 'a Valkyrie::MetadataAdapter' do |passed_adapter|
   subject { passed_adapter || adapter }
   it { is_expected.to respond_to(:persister).with(0).arguments }
   it { is_expected.to respond_to(:query_service).with(0).arguments }
+  it "caches query_service so it can register custom queries" do
+    expect(subject.query_service.custom_queries.query_handlers.object_id).to eq subject.query_service.custom_queries.query_handlers.object_id
+  end
 end


### PR DESCRIPTION
Registration is at the instance level of the query service, but it was
generating a new one every time. This preserves custom queries.