### PR TITLE
Array defaults are not modifiable

### DIFF
--- a/valkyrie/lib/valkyrie/types.rb
+++ b/valkyrie/lib/valkyrie/types.rb
@@ -23,8 +23,10 @@ module Valkyrie
       value.select(&:present?).uniq.map do |val|
         Anything[val]
       end
-    end.default([])
-    Array = Dry::Types['coercible.array'].default([])
+    end.default([].freeze)
+
+    Array = Dry::Types['coercible.array'].default([].freeze)
+
     # Used for when an input may be an array, but the output needs to be a
     # single string.
     SingleValuedString = Valkyrie::Types::String.constructor do |value|

--- a/valkyrie/spec/valkyrie/types_spec.rb
+++ b/valkyrie/spec/valkyrie/types_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Valkyrie::Types do
   before do
     class Resource < Valkyrie::Resource
       attribute :title, Valkyrie::Types::SingleValuedString
+      attribute :authors, Valkyrie::Types::Array
     end
   end
   after do
@@ -15,6 +16,13 @@ RSpec.describe Valkyrie::Types do
     it "returns the first of a set of values" do
       resource = Resource.new(title: ["one", "two"])
       expect(resource.title).to eq "one"
+    end
+  end
+
+  describe 'The array type' do
+    it 'is not modifiable' do
+      # We don't want to modify the defaults in the schema.
+      expect { Resource.new.authors << 'foo' }.to raise_error(RuntimeError, "can't modify frozen Array")
     end
   end
 end


### PR DESCRIPTION
Otherwise using the concat (or `<<` operator) on an instance, causes the schema to be modified.