### PR TITLE
add composite_indexer

### DIFF
--- a/valkyrie/lib/valkyrie/persistence/solr.rb
+++ b/valkyrie/lib/valkyrie/persistence/solr.rb
@@ -2,5 +2,6 @@
 module Valkyrie::Persistence
   module Solr
     require 'valkyrie/persistence/solr/metadata_adapter'
+    require 'valkyrie/persistence/solr/composite_indexer'
   end
 end

--- a/valkyrie/lib/valkyrie/persistence/solr/composite_indexer.rb
+++ b/valkyrie/lib/valkyrie/persistence/solr/composite_indexer.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+module Valkyrie::Persistence::Solr
+  class CompositeIndexer
+    attr_reader :indexers
+    def initialize(*indexers)
+      @indexers = indexers
+    end
+
+    def new(resource:)
+      Instance.new(indexers, resource: resource)
+    end
+
+    class Instance
+      attr_reader :indexers, :resource
+      def initialize(indexers, resource:)
+        @resource = resource
+        @indexers = indexers.map { |i| i.new(resource: resource) }
+      end
+
+      def to_solr
+        indexers.map(&:to_solr).inject({}, &:merge)
+      end
+    end
+  end
+end

--- a/valkyrie/spec/valkyrie/persistence/solr/composite_indexer_spec.rb
+++ b/valkyrie/spec/valkyrie/persistence/solr/composite_indexer_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'valkyrie/specs/shared_specs'
+
+RSpec.describe Valkyrie::Persistence::Solr::CompositeIndexer do
+  let(:adapter) { Valkyrie::Persistence::Solr::MetadataAdapter.new(connection: client, resource_indexer: composite_indexer) }
+  let(:composite_indexer) { described_class.new indexer }
+  let(:indexer) { ResourceIndexer }
+  let(:client) { RSolr.connect(url: SOLR_TEST_URL) }
+  let(:resource) { Resource.new(title: ["Test"], other_title: ["Author"]) }
+
+  before do
+    class ResourceIndexer
+      attr_reader :resource
+
+      def initialize(resource:)
+        @resource = resource
+      end
+
+      def to_solr
+        {
+          "combined_title_ssim" => resource.title + resource.other_title
+        }
+      end
+    end
+    class Resource < Valkyrie::Resource
+      attribute :id, Valkyrie::Types::ID.optional
+      attribute :title, Valkyrie::Types::Set
+      attribute :other_title, Valkyrie::Types::Set
+    end
+  end
+  after do
+    Object.send(:remove_const, :ResourceIndexer)
+    Object.send(:remove_const, :Resource)
+  end
+
+  it "adds custom indexing from the embedded Indexer" do
+    expect(adapter.resource_factory.from_resource(resource: resource)["combined_title_ssim"]).to eq ["Test", "Author"]
+  end
+end


### PR DESCRIPTION
Added the CompositeIndexer class from Figgy:
https://github.com/pulibrary/figgy/blob/master/app/indexers/composite_indexer.rb

Namespaced under persistence/solr

Plus test which checks that an embedded indexer works. I don't think this needs a shared_spec given it's testing solr indexing.