### PR TITLE
Check that the resource responds to member_ids before calling it

### DIFF
--- a/valkyrie/lib/valkyrie/persistence/fedora/query_service.rb
+++ b/valkyrie/lib/valkyrie/persistence/fedora/query_service.rb
@@ -33,6 +33,7 @@ module Valkyrie::Persistence::Fedora
     end
 
     def find_members(resource:, model: nil)
+      return [] unless resource.respond_to? :member_ids
       result = Array(resource.member_ids).lazy.map do |id|
         find_by(id: id)
       end.select(&:present?)

--- a/valkyrie/lib/valkyrie/persistence/memory/query_service.rb
+++ b/valkyrie/lib/valkyrie/persistence/memory/query_service.rb
@@ -85,6 +85,7 @@ module Valkyrie::Persistence::Memory
     end
 
     def member_ids(resource:)
+      return [] unless resource.respond_to? :member_ids
       resource.member_ids || []
     end
 

--- a/valkyrie/lib/valkyrie/specs/shared_specs/queries.rb
+++ b/valkyrie/lib/valkyrie/specs/shared_specs/queries.rb
@@ -97,6 +97,14 @@ RSpec.shared_examples 'a Valkyrie query provider' do
           expect(subject.to_a).to eq []
         end
       end
+
+      context "when the model doesn't have member_ids" do
+        let(:parent) { persister.save(resource: SecondResource.new) }
+
+        it "returns an empty array" do
+          expect(subject.to_a).to eq []
+        end
+      end
     end
 
     context "filtering by model" do
@@ -167,6 +175,14 @@ RSpec.shared_examples 'a Valkyrie query provider' do
       child1 = persister.save(resource: resource_class.new)
 
       expect(query_service.find_parents(resource: child1).to_a).to eq []
+    end
+
+    context "when the model doesn't have member_ids" do
+      let(:child1) { persister.save(resource: SecondResource.new) }
+
+      it "returns an empty array if there are none" do
+        expect(query_service.find_parents(resource: child1).to_a).to eq []
+      end
     end
   end
 


### PR DESCRIPTION
Without this check having a resource without a member_ids property in the cache causes `find_parents` and other queries to throw a `NoMethodError`.

I think the second shared spec which I added (to cover the original issue) doesn't make a whole lot of sense but it correctly fails the memory adapter as it currently is.