### PR TITLE
ChangeSet#multiple? returns false rather than nil.

### DIFF
--- a/valkyrie/lib/valkyrie/change_set.rb
+++ b/valkyrie/lib/valkyrie/change_set.rb
@@ -38,7 +38,7 @@ module Valkyrie
     # @param field [Symbol]
     # @return [Boolean]
     def required?(field)
-      self.class.definitions[field.to_s][:required]
+      self.class.definitions[field.to_s][:required] == true
     end
 
     # Quick setter for fields that should be in a changeset. Defaults to multiple,

--- a/valkyrie/spec/valkyrie/change_set_spec.rb
+++ b/valkyrie/spec/valkyrie/change_set_spec.rb
@@ -37,8 +37,9 @@ RSpec.describe Valkyrie::ChangeSet do
     it "is true when marked" do
       expect(change_set.required?(:title)).to eq true
     end
+
     it "is false when not marked" do
-      expect(change_set.required?(:files)).not_to eq true
+      expect(change_set.required?(:files)).to eq false
     end
   end
 


### PR DESCRIPTION
The rails tag helper interprets `required=>nil` as `"required"=>""`
which is a required field.