### PR TITLE
to_param must return a string

### DIFF
--- a/valkyrie/lib/valkyrie/resource.rb
+++ b/valkyrie/lib/valkyrie/resource.rb
@@ -83,7 +83,7 @@ module Valkyrie
     end
 
     def to_param
-      id
+      to_key.map(&:to_s).join('-')
     end
 
     # @note Added for ActiveModel compatibility

--- a/valkyrie/spec/valkyrie/resource_spec.rb
+++ b/valkyrie/spec/valkyrie/resource_spec.rb
@@ -48,6 +48,13 @@ RSpec.describe Valkyrie::Resource do
     end
   end
 
+  describe "#to_param" do
+    it "returns the record's id as a string" do
+      resource.id = "test"
+      expect(resource.to_param).to eq 'test'
+    end
+  end
+
   describe "#to_model" do
     it "returns itself" do
       expect(resource.to_model).to eq resource


### PR DESCRIPTION
Otherwise controllers or controller tests must cast `params[:id].to_s`

The equivalent ActiveModel behavior is here:
https://github.com/rails/rails/blob/47eadb68bfcae1641b019e07e051aa39420685fb/activemodel/lib/active_model/conversion.rb#L80-L84