### PR TITLE
Ensure that created_at is actually a String

### DIFF
--- a/lib/valkyrie/persistence/solr/model_converter.rb
+++ b/lib/valkyrie/persistence/solr/model_converter.rb
@@ -25,7 +25,11 @@ module Valkyrie::Persistence::Solr
     # @return [String] ISO-8601 timestamp in UTC of the created_at for this solr
     #   document.
     def created_at
-      resource_attributes[:created_at] || Time.current.utc.iso8601
+      if resource_attributes[:created_at]
+        DateTime.parse(resource_attributes[:created_at].to_s).utc.iso8601
+      else
+        Time.current.utc.iso8601
+      end
     end
 
     # @return [Hash] Solr document to index.

--- a/spec/valkyrie/persistence/solr/model_converter_spec.rb
+++ b/spec/valkyrie/persistence/solr/model_converter_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Valkyrie::Persistence::Solr::ModelConverter do
   let(:resource_factory) { adapter.resource_factory }
   let(:adapter) { Valkyrie::Persistence::Solr::MetadataAdapter.new(connection: client) }
   let(:client) { RSolr.connect(url: SOLR_TEST_URL) }
+  let(:created_at) { Time.now.utc }
   before do
     class Resource < Valkyrie::Resource
       attribute :id, Valkyrie::Types::ID.optional
@@ -22,7 +23,7 @@ RSpec.describe Valkyrie::Persistence::Solr::ModelConverter do
                     internal_resource: 'Resource',
                     attributes:
                     {
-                      created_at: Time.at(0).utc,
+                      created_at: created_at,
                       title: ["Test", RDF::Literal.new("French", language: :fr)],
                       author: ["Author"]
                     })
@@ -42,9 +43,24 @@ RSpec.describe Valkyrie::Persistence::Solr::ModelConverter do
         author_ssim: ["Author"],
         author_tesim: ["Author"],
         author_tsim: ["Author"],
-        created_at_dtsi: Time.at(0).utc.iso8601,
+        created_at_dtsi: created_at.iso8601,
         internal_resource_ssim: ["Resource"]
       )
+    end
+  end
+
+  describe "#created_at" do
+    context "when created_at attribute is a Time" do
+      it "returns a String" do
+        expect(mapper.created_at).to be_a String
+      end
+    end
+
+    context "when created_at attribute is nil" do
+      let(:created_at) { nil }
+      it "returns a String" do
+        expect(mapper.created_at).to be_a String
+      end
     end
   end
 end


### PR DESCRIPTION
`#created_at` reports that it returns a String but before this change it was often returning a Time because `resource_attribute[:created_at]` is generally a Time and it wasn't being coerced.  This was leading to oddness in Hyrax when using the `ModelConverter` to create `SolrDocument`s from a `Valkyrie::Resource` for tests.