### PR TITLE
Move solr commit param to class constant

### DIFF
--- a/lib/valkyrie/persistence/solr/repository.rb
+++ b/lib/valkyrie/persistence/solr/repository.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 module Valkyrie::Persistence::Solr
   class Repository
+    COMMIT_PARAMS = { softCommit: true }.freeze
+
     attr_reader :resources, :connection, :resource_factory
     def initialize(resources:, connection:, resource_factory:)
       @resources = resources
@@ -13,14 +15,14 @@ module Valkyrie::Persistence::Solr
         generate_id(resource) if resource.id.blank?
         solr_document(resource)
       end
-      connection.add documents, params: { softCommit: true }
+      connection.add documents, params: COMMIT_PARAMS
       documents.map do |document|
         resource_factory.to_resource(object: document.stringify_keys)
       end
     end
 
     def delete
-      connection.delete_by_id resources.map { |resource| resource.id.to_s }, params: { softCommit: true }
+      connection.delete_by_id resources.map { |resource| resource.id.to_s }, params: COMMIT_PARAMS
       resources
     end
 


### PR DESCRIPTION
This will let downstream tests override the autocommit without the overhead of changing the adapter's public interface.