### PR TITLE
Exploring valkyrie

### DIFF
--- a/lib/valkyrie/persistence/memory/query_service.rb
+++ b/lib/valkyrie/persistence/memory/query_service.rb
@@ -27,8 +27,8 @@ module Valkyrie::Persistence::Memory
     # @param model [Class] Class to query for.
     # @return [Array<Valkyrie::Resource>] All objects in the persistence backend
     #   with the given class.
-    def find_all_of_model(model:)
-      cache.values.select do |obj|
+    def find_all_of_model(model:, from_results: find_all)
+      from_results.select do |obj|
         obj.is_a?(model)
       end
     end
@@ -42,7 +42,7 @@ module Valkyrie::Persistence::Memory
         find_by(id: id)
       end
       return result unless model
-      result.select { |obj| obj.is_a?(model) }
+      find_all_of_model(model: model, from_results: result)
     end
 
     # @param resource [Valkyrie::Resource] Model whose property is being searched.
@@ -78,8 +78,8 @@ module Valkyrie::Persistence::Memory
     # @return [Array<Valkyrie::Resource>] All resources which are parents of the given
     #   `resource`. This means the resource's `id` appears in their `member_ids`
     #   array.
-    def find_parents(resource:)
-      cache.values.select do |record|
+    def find_parents(resource:, from_results: find_all)
+      from_results.select do |record|
         member_ids(resource: record).include?(resource.id)
       end
     end

--- a/lib/valkyrie/persistence/memory/query_service.rb
+++ b/lib/valkyrie/persistence/memory/query_service.rb
@@ -27,8 +27,8 @@ module Valkyrie::Persistence::Memory
     # @param model [Class] Class to query for.
     # @return [Array<Valkyrie::Resource>] All objects in the persistence backend
     #   with the given class.
-    def find_all_of_model(model:, from_results: find_all)
-      from_results.select do |obj|
+    def find_all_of_model(model:)
+      cache.values.select do |obj|
         obj.is_a?(model)
       end
     end
@@ -42,7 +42,7 @@ module Valkyrie::Persistence::Memory
         find_by(id: id)
       end
       return result unless model
-      find_all_of_model(model: model, from_results: result)
+      result.select { |obj| obj.is_a?(model) }
     end
 
     # @param resource [Valkyrie::Resource] Model whose property is being searched.
@@ -78,8 +78,8 @@ module Valkyrie::Persistence::Memory
     # @return [Array<Valkyrie::Resource>] All resources which are parents of the given
     #   `resource`. This means the resource's `id` appears in their `member_ids`
     #   array.
-    def find_parents(resource:, from_results: find_all)
-      from_results.select do |record|
+    def find_parents(resource:)
+      cache.values.select do |record|
         member_ids(resource: record).include?(resource.id)
       end
     end

--- a/lib/valkyrie/persistence/solr/queries.rb
+++ b/lib/valkyrie/persistence/solr/queries.rb
@@ -9,5 +9,30 @@ module Valkyrie::Persistence::Solr
     require 'valkyrie/persistence/solr/queries/find_inverse_references_query'
     require 'valkyrie/persistence/solr/queries/find_members_query'
     require 'valkyrie/persistence/solr/queries/find_references_query'
+
+    # @api private
+    def self.run_find_by_id_query(id, connection:, resource_factory:)
+      FindByIdQuery.new(id, connection: connection, resource_factory: resource_factory).run
+    end
+
+    # @api private
+    def self.run_find_all_query(connection:, resource_factory:, model: nil)
+      FindAllQuery.new(connection: connection, resource_factory: resource_factory, model: model).run
+    end
+
+    # @api private
+    def self.run_find_members(resource:, model: nil, connection:, resource_factory:)
+      FindMembersQuery.new(resource: resource, model: model, connection: connection, resource_factory: resource_factory).run
+    end
+
+    # @api private
+    def self.run_find_references_query(resource:, property:, connection:, resource_factory:)
+      FindReferencesQuery.new(resource: resource, property: property, connection: connection, resource_factory: resource_factory).run
+    end
+
+    # @api private
+    def self.run_find_inverse_references_query(resource:, property:, connection:, resource_factory:)
+      FindInverseReferencesQuery.new(resource: resource, property: property, connection: connection, resource_factory: resource_factory).run
+    end
   end
 end

--- a/lib/valkyrie/persistence/solr/query_service.rb
+++ b/lib/valkyrie/persistence/solr/query_service.rb
@@ -5,25 +5,26 @@ module Valkyrie::Persistence::Solr
     attr_reader :connection, :resource_factory
     # @param connection [RSolr::Client]
     # @param resource_factory [Valkyrie::Persistence::Solr::ResourceFactory]
-    def initialize(connection:, resource_factory:)
+    def initialize(connection:, resource_factory:, query_runner: default_query_runner)
       @connection = connection
       @resource_factory = resource_factory
+      @query_runner = query_runner
     end
 
     # (see Valkyrie::Persistence::Memory::QueryService#find_by)
     def find_by(id:)
       validate_id(id)
-      Valkyrie::Persistence::Solr::Queries::FindByIdQuery.new(id, connection: connection, resource_factory: resource_factory).run
+      query_runner::FindByIdQuery.new(id, connection: connection, resource_factory: resource_factory).run
     end
 
     # (see Valkyrie::Persistence::Memory::QueryService#find_all)
     def find_all
-      Valkyrie::Persistence::Solr::Queries::FindAllQuery.new(connection: connection, resource_factory: resource_factory).run
+      query_runner::FindAllQuery.new(connection: connection, resource_factory: resource_factory).run
     end
 
     # (see Valkyrie::Persistence::Memory::QueryService#find_all_of_model)
     def find_all_of_model(model:)
-      Valkyrie::Persistence::Solr::Queries::FindAllQuery.new(connection: connection, resource_factory: resource_factory, model: model).run
+      query_runner::FindAllQuery.new(connection: connection, resource_factory: resource_factory, model: model).run
     end
 
     # (see Valkyrie::Persistence::Memory::QueryService#find_parents)
@@ -33,17 +34,17 @@ module Valkyrie::Persistence::Solr
 
     # (see Valkyrie::Persistence::Memory::QueryService#find_members)
     def find_members(resource:, model: nil)
-      Valkyrie::Persistence::Solr::Queries::FindMembersQuery.new(resource: resource, model: model, connection: connection, resource_factory: resource_factory).run
+      query_runner::FindMembersQuery.new(resource: resource, model: model, connection: connection, resource_factory: resource_factory).run
     end
 
     # (see Valkyrie::Persistence::Memory::QueryService#find_references_by)
     def find_references_by(resource:, property:)
-      Valkyrie::Persistence::Solr::Queries::FindReferencesQuery.new(resource: resource, property: property, connection: connection, resource_factory: resource_factory).run
+      query_runner::FindReferencesQuery.new(resource: resource, property: property, connection: connection, resource_factory: resource_factory).run
     end
 
     # (see Valkyrie::Persistence::Memory::QueryService#find_inverse_references_by)
     def find_inverse_references_by(resource:, property:)
-      Valkyrie::Persistence::Solr::Queries::FindInverseReferencesQuery.new(resource: resource, property: property, connection: connection, resource_factory: resource_factory).run
+      query_runner::FindInverseReferencesQuery.new(resource: resource, property: property, connection: connection, resource_factory: resource_factory).run
     end
 
     def custom_queries
@@ -51,6 +52,12 @@ module Valkyrie::Persistence::Solr
     end
 
     private
+
+      attr_reader :query_runner
+
+      def default_query_runner
+        Valkyrie::Persistence::Solr::Queries
+      end
 
       def validate_id(id)
         raise ArgumentError, 'id must be a Valkyrie::ID' unless id.is_a? Valkyrie::ID

--- a/lib/valkyrie/persistence/solr/query_service.rb
+++ b/lib/valkyrie/persistence/solr/query_service.rb
@@ -14,17 +14,17 @@ module Valkyrie::Persistence::Solr
     # (see Valkyrie::Persistence::Memory::QueryService#find_by)
     def find_by(id:)
       validate_id(id)
-      query_runner::FindByIdQuery.new(id, connection: connection, resource_factory: resource_factory).run
+      query_runner.run_find_by_id_query(id, connection: connection, resource_factory: resource_factory)
     end
 
     # (see Valkyrie::Persistence::Memory::QueryService#find_all)
     def find_all
-      query_runner::FindAllQuery.new(connection: connection, resource_factory: resource_factory).run
+      query_runner.run_find_all_query(connection: connection, resource_factory: resource_factory)
     end
 
     # (see Valkyrie::Persistence::Memory::QueryService#find_all_of_model)
     def find_all_of_model(model:)
-      query_runner::FindAllQuery.new(connection: connection, resource_factory: resource_factory, model: model).run
+      query_runner.run_find_all_query(connection: connection, resource_factory: resource_factory, model: model)
     end
 
     # (see Valkyrie::Persistence::Memory::QueryService#find_parents)
@@ -34,17 +34,17 @@ module Valkyrie::Persistence::Solr
 
     # (see Valkyrie::Persistence::Memory::QueryService#find_members)
     def find_members(resource:, model: nil)
-      query_runner::FindMembersQuery.new(resource: resource, model: model, connection: connection, resource_factory: resource_factory).run
+      query_runner.run_find_members(resource: resource, model: model, connection: connection, resource_factory: resource_factory)
     end
 
     # (see Valkyrie::Persistence::Memory::QueryService#find_references_by)
     def find_references_by(resource:, property:)
-      query_runner::FindReferencesQuery.new(resource: resource, property: property, connection: connection, resource_factory: resource_factory).run
+      query_runner.run_find_references_query(resource: resource, property: property, connection: connection, resource_factory: resource_factory)
     end
 
     # (see Valkyrie::Persistence::Memory::QueryService#find_inverse_references_by)
     def find_inverse_references_by(resource:, property:)
-      query_runner::FindInverseReferencesQuery.new(resource: resource, property: property, connection: connection, resource_factory: resource_factory).run
+      query_runner.run_find_inverse_references_query(resource: resource, property: property, connection: connection, resource_factory: resource_factory)
     end
 
     def custom_queries


### PR DESCRIPTION
## Reducing duplication of knowledge

801bb2230c89f8dcba3696c709e1d8616faec18e

This is a minor refactor for the in-memory adapter. It is intended to
reduce the duplication of knowledge.

The other purpose is in exploring Valkyrie's implementation details.

## Adding query_runner to Solr::QueryService

cdd4fd00482caf32a662a4e1471da2c3d92155ff

There is a lot of replication of the module space; This modification
allows for dependency inversion.

Further considerations are to extract the instantiation and run coupling
into methods on the Queries module.

## Extracting methods to narrow dependency interface

3ada4877d20ee736dcdca0266e52faecdc957607

Having extracted the query_runner, I wanted to then extract a clear
interaction between the QueryService and the Query module's submodules.

From this refactoring, we can then explore the interaction of the
custom query object in the QueryService as part of the parameterized
query_runner.

## Revert "Reducing duplication of knowledge"

0c84f7830f053ac4edb5d8a26a8a59b740ed0df7

This reverts commit 801bb2230c89f8dcba3696c709e1d8616faec18e.

From conversations on https://github.com/samvera-labs/valkyrie/pull/331
I am reverting the proposed change. I chose not to remove the commit
and to instead revert the commit to ensure that we capture the
conversation regarding this change.

tpendragon:

> I'm a little concerned about this having a different method signature
> than all the other query services. Sure, it's an optional parameter,
> but it sets a precedent I'm not sure I'm comfortable with.

jeremyf:

> I can appreciate the concern, and my perspective if so long as it
> remains optional, it is a reasonable extension. People may have use
> cases in their adapters that require these optional parameters. This
> follows the "open for extension principle"
>
> I'm wondering about adding a `**` to swallow additional `kwargs`
> would be a good approach in updating the interface. The following
> would be the generally acceptable format.
>
> ```ruby
> def find_all_of_model(model:, **)
> end
> ```
>
> I have some implementation details on a more thorough testing of
> kwargs that are required and options: https://github.com/samvera-labs/samvera-nesting_indexer/blob/master/lib/samvera/nesting_indexer/adapters/interface_behavior_spec.rb

tpendragon:

> Adapters aren't really meant to be sub-classed, so I'm trying not to
> implement use cases which "may" exist. I think we shouldn't do this
> commit for now.
>
> One middle-ground is we could just change `cache.values` to `find_all`
> and get a similar result. Maybe a baby step in the direction you're
> going for?

jeremyf:

> @tpendragon I'm not advocating for sub-classing. I'm looking at method
> signatures of the adapter interface. By adding `**kwargs` to the
> interface, we end up with a forward flexible method signature.
>
> That said, I'll tweak and adjust to use `find_all` instead of
> `cache.values` to move this PR forward.
