### PR TITLE
Exposing methods to reduce upstream chaining

### DIFF
--- a/lib/valkyrie/metadata_adapter.rb
+++ b/lib/valkyrie/metadata_adapter.rb
@@ -14,10 +14,34 @@ module Valkyrie
       # Find an adapter by its short name.
       # @param short_name [Symbol]
       # @return [#persister,#query_service]
+      # @raise RuntimeError when the given short_name is not found amongst the registered adapters
       def find(short_name)
         symbolized_key = short_name.to_sym
+        # TODO: Instead of RuntimeError could we simply perform `adapters.fetch(symbolized_key)` this would raise a KeyError instead
         return adapters[symbolized_key] if adapters.key?(symbolized_key)
         raise "Unable to find unregistered adapter `#{short_name}'"
+      end
+
+      # @api public
+      # @since 0.1.0
+      # Find the persister registered under the given short-name
+      #
+      # @param short_name [Symbol]
+      # @return [Object] an object that behaves like "a Valkyrie::Persister"
+      # @see GEM_ROOT/lib/valkyrie/specs/shared_specs/persister.rb
+      def find_persister_for(short_name)
+        find(short_name).persister
+      end
+
+      # @api public
+      # @since 0.1.0
+      # Find the query service registered under the given short-name
+      #
+      # @param short_name [Symbol]
+      # @return [Object] an object that behaves like "a Valkyrie query provider"
+      # @see GEM_ROOT/lib/valkyrie/specs/shared_specs/queries.rb
+      def find_query_service_for(short_name)
+        find(short_name).query_service
       end
     end
   end

--- a/lib/valkyrie/metadata_adapter.rb
+++ b/lib/valkyrie/metadata_adapter.rb
@@ -17,7 +17,6 @@ module Valkyrie
       # @raise RuntimeError when the given short_name is not found amongst the registered adapters
       def find(short_name)
         symbolized_key = short_name.to_sym
-        # TODO: Instead of RuntimeError could we simply perform `adapters.fetch(symbolized_key)` this would raise a KeyError instead
         return adapters[symbolized_key] if adapters.key?(symbolized_key)
         raise "Unable to find unregistered adapter `#{short_name}'"
       end

--- a/spec/valkyrie/metadata_adapter_spec.rb
+++ b/spec/valkyrie/metadata_adapter_spec.rb
@@ -2,8 +2,18 @@
 require 'spec_helper'
 
 RSpec.describe Valkyrie::MetadataAdapter do
+  let(:adapter) do
+    Class.new do
+      def self.persister
+        :the_persister
+      end
+
+      def self.query_service
+        :the_query_service
+      end
+    end
+  end
   describe ".register" do
-    let(:adapter) { instance_double(described_class) }
     it "registers an adapter to a short name" do
       described_class.register adapter, :test_adapter
 
@@ -16,6 +26,31 @@ RSpec.describe Valkyrie::MetadataAdapter do
     context 'when no adapter is registered' do
       it 'raises an error' do
         expect { find }.to raise_error "Unable to find unregistered adapter `huh?'"
+      end
+    end
+  end
+
+  describe '.find_persister_for' do
+    subject(:find_persister_for) { described_class.find_persister_for(:test_adapter) }
+    context 'with a registered adapter' do
+      before do
+        described_class.register(adapter, :test_adapter)
+      end
+      it 'returns the adapters persister object' do
+        expect(find_persister_for).to eq(adapter.persister)
+      end
+    end
+    # rubocop:enable RSpec/VerifiedDoubles
+  end
+
+  describe '.find_query_service_for' do
+    subject(:find_query_service_for) { described_class.find_query_service_for(:test_adapter) }
+    context 'with a registered adapter' do
+      before do
+        described_class.register(adapter, :test_adapter)
+      end
+      it 'returns the adapters query_service object' do
+        expect(find_query_service_for).to eq(adapter.query_service)
       end
     end
   end


### PR DESCRIPTION
Prior to this commit, the following was used to retrieve a `persister`
or a `query_service`:

```ruby
Valkyrie::MetadataAdapter.find(:indexing_persister).query_service
```

With the following change, we can now use:

```ruby
Valkyrie::MetadataAdapter.find_query_service_for(:indexing_persister)
```

In removing the method chaining, any upstream dependency inversion
becomes easier to implement and utilize.

Responding to https://github.com/samvera/hyrax/pull/2358
https://github.com/samvera/hyrax/pull/2358/files/b50c05a38c1dbe511fa46016db50b68373142014#diff-21e2261d854a7e8fb6ea96ec414bc7d8R47