### PR TITLE
Working on valkyrie understanding part 2

### DIFF
--- a/lib/valkyrie/storage_adapter.rb
+++ b/lib/valkyrie/storage_adapter.rb
@@ -10,20 +10,23 @@ module Valkyrie
       # @param short_name [Symbol]
       # @return [void]
       def register(storage_adapter, short_name)
-        storage_adapters[short_name] = storage_adapter
+        storage_adapters[short_name.to_sym] = storage_adapter
       end
 
       # @param short_name [Symbol]
       # @return [void]
       def unregister(short_name)
-        storage_adapters.delete(short_name)
+        storage_adapters.delete(short_name.to_sym)
       end
 
       # Find the adapter associated with the provided short name
       # @param short_name [Symbol]
       # @return [Valkyrie::StorageAdapter]
+      # @raise Valkyrie::StorageAdapter::AdapterNotFoundError when we are unable to find the named adapter
       def find(short_name)
-        storage_adapters[short_name]
+        storage_adapters.fetch(short_name.to_sym)
+      rescue KeyError
+        raise "Unable to find #{self} with short_name of #{short_name.to_sym.inspect}. Registered adapters are #{storage_adapters.keys.inspect}"
       end
 
       # Search through all registered storage adapters until it finds one that

--- a/lib/valkyrie/storage_adapter.rb
+++ b/lib/valkyrie/storage_adapter.rb
@@ -10,13 +10,13 @@ module Valkyrie
       # @param short_name [Symbol]
       # @return [void]
       def register(storage_adapter, short_name)
-        storage_adapters[short_name.to_sym] = storage_adapter
+        storage_adapters[short_name] = storage_adapter
       end
 
       # @param short_name [Symbol]
       # @return [void]
       def unregister(short_name)
-        storage_adapters.delete(short_name.to_sym)
+        storage_adapters.delete(short_name)
       end
 
       # Find the adapter associated with the provided short name
@@ -24,9 +24,9 @@ module Valkyrie
       # @return [Valkyrie::StorageAdapter]
       # @raise Valkyrie::StorageAdapter::AdapterNotFoundError when we are unable to find the named adapter
       def find(short_name)
-        storage_adapters.fetch(short_name.to_sym)
+        storage_adapters.fetch(short_name)
       rescue KeyError
-        raise "Unable to find #{self} with short_name of #{short_name.to_sym.inspect}. Registered adapters are #{storage_adapters.keys.inspect}"
+        raise "Unable to find #{self} with short_name of #{short_name.inspect}. Registered adapters are #{storage_adapters.keys.inspect}"
       end
 
       # Search through all registered storage adapters until it finds one that

--- a/lib/valkyrie/storage_adapter.rb
+++ b/lib/valkyrie/storage_adapter.rb
@@ -37,7 +37,7 @@ module Valkyrie
       end
 
       # Search through all registered storage adapters until it finds one that
-      # can handle the passed in identifier.  The call delete on that adapter
+      # can handle the passed in identifier.  Then call delete on that adapter
       # with the given identifier.
       # @param id [Valkyrie::ID]
       def delete(id:)
@@ -45,7 +45,10 @@ module Valkyrie
       end
 
       # Return the registered storage adapter which handles the given ID.
+      # @param id [Valkyrie::ID]
+      # @return [Valkyrie::StorageAdapter]
       def adapter_for(id:)
+        # TODO: Determine the appropriate response when we have an unhandled :id
         storage_adapters.values.find do |storage_adapter|
           storage_adapter.handles?(id: id)
         end

--- a/spec/valkyrie/storage_adapter_spec.rb
+++ b/spec/valkyrie/storage_adapter_spec.rb
@@ -15,6 +15,14 @@ RSpec.describe Valkyrie::StorageAdapter do
     end
   end
 
+  describe '.find' do
+    context "with an unregistered adapter" do
+      it "raises a #{described_class}::AdapterNotFoundError" do
+        expect { described_class.find(:obviously_missing) }.to raise_error(RuntimeError, /:obviously_missing/)
+      end
+    end
+  end
+
   describe ".find_by" do
     it "delegates down to its storage_adapters to find one which handles the given identifier" do
       file = instance_double(Valkyrie::StorageAdapter::StreamFile, id: "yo")


### PR DESCRIPTION
## Updating StorageAdapter API documentation

131dad8d6f02c06dca712bec5e15d7e8d24e93e9


## Raising error on missing StorageAdapter.find

83b41768d82b75366f527dca32ca23becdf8f976

I'm assuming that failure to find an adapter should raise an exception
instead of returning a `nil` object.

This behavior mirrors the Valkyrie::MetadataAdapter.find behavior.
