### PR TITLE
Support string type for primary key

### DIFF
--- a/db/migrate/20161007101725_create_orm_resources.rb
+++ b/db/migrate/20161007101725_create_orm_resources.rb
@@ -1,9 +1,16 @@
 # frozen_string_literal: true
 class CreateOrmResources < ActiveRecord::Migration[5.0]
   def change
-    create_table :orm_resources, id: :uuid do |t|
-      t.jsonb :metadata, null: false, default: {}
-      t.timestamps
+    if ENV["VALKYRIE_ID_TYPE"] == "string"
+      create_table :orm_resources, { id: :text, default: -> { '(uuid_generate_v4())::text' } } do |t|
+        t.jsonb :metadata, null: false, default: {}
+        t.timestamps
+      end
+    else
+      create_table :orm_resources, id: :uuid do |t|
+        t.jsonb :metadata, null: false, default: {}
+        t.timestamps
+      end
     end
     add_index :orm_resources, :metadata, using: :gin
   end

--- a/db/migrate/20161007101725_create_orm_resources.rb
+++ b/db/migrate/20161007101725_create_orm_resources.rb
@@ -2,7 +2,7 @@
 class CreateOrmResources < ActiveRecord::Migration[5.0]
   def change
     if ENV["VALKYRIE_ID_TYPE"] == "string"
-      create_table :orm_resources, { id: :text, default: -> { '(uuid_generate_v4())::text' } } do |t|
+      create_table :orm_resources, id: :text, default: -> { '(uuid_generate_v4())::text' } do |t|
         t.jsonb :metadata, null: false, default: {}
         t.timestamps
       end

--- a/db/migrate/20161007101725_create_orm_resources.rb
+++ b/db/migrate/20161007101725_create_orm_resources.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 class CreateOrmResources < ActiveRecord::Migration[5.0]
-  def change
-    options = if ENV["VALKYRIE_ID_TYPE"] == "string"
+  def options
+    if ENV["VALKYRIE_ID_TYPE"] == "string"
       { id: :text, default: -> { '(uuid_generate_v4())::text' } }
     else
       { id: :uuid }
     end
+  end
+
+  def change
     create_table :orm_resources, **options do |t|
       t.jsonb :metadata, null: false, default: {}
       t.timestamps

--- a/db/migrate/20161007101725_create_orm_resources.rb
+++ b/db/migrate/20161007101725_create_orm_resources.rb
@@ -1,16 +1,14 @@
 # frozen_string_literal: true
 class CreateOrmResources < ActiveRecord::Migration[5.0]
   def change
-    if ENV["VALKYRIE_ID_TYPE"] == "string"
-      create_table :orm_resources, id: :text, default: -> { '(uuid_generate_v4())::text' } do |t|
-        t.jsonb :metadata, null: false, default: {}
-        t.timestamps
-      end
+    options = if ENV["VALKYRIE_ID_TYPE"] == "string"
+      { id: :text, default: -> { '(uuid_generate_v4())::text' } }
     else
-      create_table :orm_resources, id: :uuid do |t|
-        t.jsonb :metadata, null: false, default: {}
-        t.timestamps
-      end
+      { id: :uuid }
+    end
+    create_table :orm_resources, **options do |t|
+      t.jsonb :metadata, null: false, default: {}
+      t.timestamps
     end
     add_index :orm_resources, :metadata, using: :gin
   end

--- a/lib/valkyrie/persistence/postgres/resource_converter.rb
+++ b/lib/valkyrie/persistence/postgres/resource_converter.rb
@@ -9,7 +9,7 @@ module Valkyrie::Persistence::Postgres
     end
 
     def convert!
-      orm_class.find_or_initialize_by(id: resource.id.to_s).tap do |orm_object|
+      orm_class.find_or_initialize_by(id: resource.id && resource.id.to_s).tap do |orm_object|
         orm_object.internal_resource = resource.internal_resource
         orm_object.metadata.merge!(resource.attributes.except(:id, :internal_resource, :created_at, :updated_at))
       end

--- a/lib/valkyrie/specs/shared_specs/persister.rb
+++ b/lib/valkyrie/specs/shared_specs/persister.rb
@@ -88,6 +88,13 @@ RSpec.shared_examples 'a Valkyrie::Persister' do |*flags|
     expect([shared_title.id, Valkyrie::ID.new("adapter://1"), "test"]).to contain_exactly(*reloaded.title)
   end
 
+  it "can override default id generation with a provided id" do
+    id = SecureRandom.uuid
+    book = persister.save(resource: resource_class.new(id: id))
+    reloaded = query_service.find_by(id: book.id)
+    expect(reloaded.id).to eq Valkyrie::ID.new(id)
+  end
+
   it "can store ::RDF::URIs" do
     book = persister.save(resource: resource_class.new(title: [::RDF::URI("http://example.com")]))
     reloaded = query_service.find_by(id: book.id)


### PR DESCRIPTION
This adds support for optionally using a string for the id field instead of a uuid so that an application can use things like NOIDs. Changes:
- Added support for specifying an env at migration time to change the id type to string. It will still use uuid_generate_v4 for the default if no id is provided, but this relieves the constraint of it being a uuid. This is required so that we can run all specs for each type to prevent regression of support for both types. Example: `VALKYRIE_ID_TYPE=string bundle exec rake db:drop db:create db:migrate && bundle exec rspec spec`
- Changed the pg queries to read the type for the id field to perform the correct casting
- Added a spec to ensure all adapters allow writing a custom id on persist
- Deep in the internals of active record's connection adapters, it's not casting id as string when the database field's type is text. Changed postgres query_service#find_by to explicitly call to_s. Not sure where else this needs to be done atm.
- Found an additional problem in resource_converter. If resource.id was nil, to_s would convert to "", which is a valid value for the string datatype. Changed it to only convert if id is present so that the insert statement leaves id as null, and the database default can be generated.