### PR TITLE
Calling super instead of a specific class

### DIFF
--- a/lib/valkyrie/resource.rb
+++ b/lib/valkyrie/resource.rb
@@ -15,7 +15,7 @@ module Valkyrie
     # Overridden to provide default attributes.
     # @note The current theory is that we should use this sparingly.
     def self.inherited(subclass)
-      ::Dry::Struct.inherited(subclass)
+      super(subclass)
       subclass.constructor_type :schema
       subclass.attribute :internal_resource, Valkyrie::Types::Any.default(subclass.to_s)
       subclass.attribute :created_at, Valkyrie::Types::DateTime.optional

--- a/spec/valkyrie/resource_spec.rb
+++ b/spec/valkyrie/resource_spec.rb
@@ -76,4 +76,20 @@ RSpec.describe Valkyrie::Resource do
       expect(resource.to_s).to eq "Resource: test"
     end
   end
+
+  context "extended class" do
+    before do
+      class MyResource < Resource
+      end
+    end
+    after do
+      Object.send(:remove_const, :MyResource)
+    end
+    subject(:resource) { MyResource.new }
+    describe "#fields" do
+      it "returns all configured parent fields as an array of symbols" do
+        expect(MyResource.fields).to eq [:internal_resource, :created_at, :updated_at, :id, :title]
+      end
+    end
+  end
 end


### PR DESCRIPTION
This allows us to get the inherited attributes of all parent classes instead of just dry-struct

fixes #329 