### PR TITLE
Creating resources with id sets created_at and new_record

### DIFF
--- a/lib/valkyrie/persistence/memory/persister.rb
+++ b/lib/valkyrie/persistence/memory/persister.rb
@@ -14,7 +14,9 @@ module Valkyrie::Persistence::Memory
     #   persistence backend.
     def save(resource:)
       resource = generate_id(resource) if resource.id.blank?
+      resource.created_at ||= Time.current
       resource.updated_at = Time.current
+      resource.new_record = false
       normalize_dates!(resource)
       cache[resource.id] = resource
     end
@@ -41,9 +43,7 @@ module Valkyrie::Persistence::Memory
     private
 
       def generate_id(resource)
-        resource.new(id: SecureRandom.uuid,
-                     created_at: Time.current,
-                     new_record: false)
+        resource.new(id: SecureRandom.uuid)
       end
 
       def normalize_dates!(resource)

--- a/lib/valkyrie/specs/shared_specs/persister.rb
+++ b/lib/valkyrie/specs/shared_specs/persister.rb
@@ -96,6 +96,11 @@ RSpec.shared_examples 'a Valkyrie::Persister' do |*flags|
     book = persister.save(resource: resource_class.new(id: id))
     reloaded = query_service.find_by(id: book.id)
     expect(reloaded.id).to eq Valkyrie::ID.new(id)
+    expect(reloaded).to be_persisted
+    expect(reloaded.created_at).not_to be_blank
+    expect(reloaded.updated_at).not_to be_blank
+    expect(reloaded.created_at).not_to be_kind_of Array
+    expect(reloaded.updated_at).not_to be_kind_of Array
   end
 
   it "can store ::RDF::URIs" do


### PR DESCRIPTION
Fixes `spec/models/hyrax/permission_template_spec.rb:16` in hyrax's valkyrie-6 branch.