### PR TITLE
Add index for updated_at to orm_resources

### DIFF
--- a/db/migrate/20180212092225_create_updated_at_index.rb
+++ b/db/migrate/20180212092225_create_updated_at_index.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class CreateUpdatedAtIndex < ActiveRecord::Migration[5.1]
+  def change
+    add_index :orm_resources, :updated_at
+  end
+end


### PR DESCRIPTION
My use case for this index is to support fixity checks. Because reaching into the (nested) metadata for a last_run_fixy_check value was not performant, we're running fixity on update and at the same time a job that checks the file set which was least-recently updated. This index will support that job.

Can of course be used for other things, like finding recently-updated models :)