### PR TITLE
Use Array.wrap for coercing arrays

### DIFF
--- a/lib/valkyrie/types.rb
+++ b/lib/valkyrie/types.rb
@@ -37,14 +37,16 @@ module Valkyrie
       end
     end
 
+    Array = Dry::Types['array'].constructor do |value|
+      ::Array.wrap(value)
+    end.default([].freeze)
+
     # Represents an array of unique values.
-    Set = Valkyrie::Types::Coercible::Array.constructor do |value|
-      value.select(&:present?).uniq.map do |val|
+    Set = Array.constructor do |value|
+      ::Array.wrap(value).select(&:present?).uniq.map do |val|
         Anything[val]
       end
     end.default([].freeze)
-
-    Array = Dry::Types['coercible.array'].default([].freeze)
 
     # Used for when an input may be an array, but the output needs to be a
     # single string.

--- a/spec/valkyrie/types_spec.rb
+++ b/spec/valkyrie/types_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Valkyrie::Types do
       attribute :authors, Valkyrie::Types::Array
       attribute :geonames_uri, Valkyrie::Types::URI
       attribute :thumbnail_id, Valkyrie::Types::ID
+      attribute :embargo_release_date, Valkyrie::Types::Set.member(Valkyrie::Types::DateTime).optional
     end
   end
   after do
@@ -68,6 +69,13 @@ RSpec.describe Valkyrie::Types do
     it 'is not modifiable' do
       # We don't want to modify the defaults in the schema.
       expect { Resource.new.authors << 'foo' }.to raise_error(RuntimeError, "can't modify frozen Array")
+    end
+  end
+
+  describe "the DateTime type" do
+    it "can be set as a time inside an array" do
+      resource = Resource.new(embargo_release_date: 2.days.ago)
+      expect(resource.embargo_release_date.first).to be_a Time
     end
   end
 end


### PR DESCRIPTION
Fixes edge cases like hashes or Times which should be cast to arrays,
but not become an array of numbers.

Closes #321, closes #320