### PR TITLE
Add test coverage for access_controls_indexer

### DIFF
--- a/lib/valkyrie/indexers/access_controls_indexer.rb
+++ b/lib/valkyrie/indexers/access_controls_indexer.rb
@@ -26,7 +26,7 @@ module Valkyrie::Indexers
             read_groups: Hydra.config[:permissions][:read].group,
             read_users: Hydra.config[:permissions][:read].individual,
             edit_groups: Hydra.config[:permissions][:edit].group,
-            edit_users: Hydra.config[:permissions][:edit].group
+            edit_users: Hydra.config[:permissions][:edit].individual
           }
         else
           {

--- a/spec/valkyrie/indexers/access_controls_indexer_spec.rb
+++ b/spec/valkyrie/indexers/access_controls_indexer_spec.rb
@@ -14,21 +14,68 @@ RSpec.describe Valkyrie::Indexers::AccessControlsIndexer do
       Object.send(:remove_const, :Resource)
       Object.send(:remove_const, :SimpleResource)
     end
-    it "indexes for Hydra::AccessControls" do
-      resource = Resource.new(read_users: ["read_user"], edit_users: ["edit_user"], read_groups: ["read_group"], edit_groups: ["edit_group"])
-      output = described_class.new(resource: resource).to_solr
-
-      expect(output["read_access_person_ssim"]).to eq ["read_user"]
-      expect(output["edit_access_person_ssim"]).to eq ["edit_user"]
-      expect(output["read_access_group_ssim"]).to eq ["read_group"]
-      expect(output["edit_access_group_ssim"]).to eq ["edit_group"]
-    end
-    context "when it's passed a resource which has no read_users" do
-      it "does nothing" do
-        resource = SimpleResource.new(read_users: ["read_user"], edit_users: ["edit_user"], read_groups: ["read_group"], edit_groups: ["edit_group"])
+    context "without Hydra::AccessControls" do
+      it "indexes without Hydra::AccessControls" do
+        resource = Resource.new(read_users: ["read_user"], edit_users: ["edit_user"], read_groups: ["read_group"], edit_groups: ["edit_group"])
         output = described_class.new(resource: resource).to_solr
 
-        expect(output).to eq({})
+        expect(output["read_access_person_ssim"]).to eq ["read_user"]
+        expect(output["edit_access_person_ssim"]).to eq ["edit_user"]
+        expect(output["read_access_group_ssim"]).to eq ["read_group"]
+        expect(output["edit_access_group_ssim"]).to eq ["edit_group"]
+      end
+      context "when it's passed a resource which has no read_users" do
+        it "does nothing" do
+          resource = SimpleResource.new(read_users: ["read_user"], edit_users: ["edit_user"], read_groups: ["read_group"], edit_groups: ["edit_group"])
+          output = described_class.new(resource: resource).to_solr
+
+          expect(output).to eq({})
+        end
+      end
+    end
+
+    context "with Hydra::AccessControls" do
+      before do
+        class EditPermission
+          def group
+            'test_edit_access_group'
+          end
+
+          def individual
+            'test_edit_access_person'
+          end
+        end
+        class ReadPermission
+          def group
+            'test_read_access_group'
+          end
+
+          def individual
+            'test_read_access_person'
+          end
+        end
+
+        module Hydra
+          class << self
+            def configure(_ = nil)
+              { permissions: { read: ReadPermission.new, edit: EditPermission.new } }
+            end
+            alias config configure
+          end
+        end
+      end
+      after do
+        Hydra.remove_possible_method(:configure)
+      end
+
+      it "indexes with Hydra::AccessControls" do
+        resource = Resource.new(read_users: ["read_user"], edit_users: ["edit_user"], read_groups: ["read_group"], edit_groups: ["edit_group"])
+        output = described_class.new(resource: resource).to_solr
+
+        expect(output["test_read_access_person"]).to eq ["read_user"]
+        expect(output["test_edit_access_person"]).to eq ["edit_user"]
+        expect(output["test_read_access_group"]).to eq ["read_group"]
+        expect(output["test_edit_access_group"]).to eq ["edit_group"]
       end
     end
   end


### PR DESCRIPTION
Closes #325

Also fixes bug wherein edit group was set twice and individual set 0
times; each now set once.