### PR TITLE
Adding test for RDF types

### DIFF
--- a/lib/valkyrie/specs/shared_specs/persister.rb
+++ b/lib/valkyrie/specs/shared_specs/persister.rb
@@ -77,10 +77,75 @@ RSpec.shared_examples 'a Valkyrie::Persister' do |*flags|
     expect(book.updated_at).not_to be_kind_of Array
   end
 
-  it "can handle language-typed RDF properties" do
-    book = persister.save(resource: resource_class.new(title: ["Test1", RDF::Literal.new("Test", language: :fr)]))
+  # Pending support for RDF::Literal boolean in postgres and solr
+  xit "can handle Boolean RDF properties" do
+    boolean_rdf = RDF::Literal.new(false)
+    book = persister.save(resource: resource_class.new(title: [boolean_rdf]))
     reloaded = query_service.find_by(id: book.id)
-    expect(reloaded.title).to contain_exactly "Test1", RDF::Literal.new("Test", language: :fr)
+    expect(reloaded.title).to contain_exactly boolean_rdf
+  end
+
+  # Pending support for RDF::Literal custom type in postgres and solr
+  xit "can handle custom-typed RDF properties" do
+    custom_rdf = RDF::Literal.new("Test", datatype: RDF::URI.parse("http://my_made_up_type"))
+    book = persister.save(resource: resource_class.new(title: [custom_rdf]))
+    reloaded = query_service.find_by(id: book.id)
+    expect(reloaded.title).to contain_exactly custom_rdf
+  end
+
+  # Pending support for RDF::Literal date in postgres and solr
+  xit "can handle Date RDF properties" do
+    date_rdf = RDF::Literal.new(Date.current)
+    book = persister.save(resource: resource_class.new(title: [date_rdf]))
+    reloaded = query_service.find_by(id: book.id)
+    expect(reloaded.title).to contain_exactly date_rdf
+  end
+
+  # Pending support for RDF::Literal date time in postgres, solr, and fedora
+  xit "can handle DateTime RDF properties" do
+    datetime_rdf = RDF::Literal.new(DateTime.current)
+    book = persister.save(resource: resource_class.new(title: [datetime_rdf]))
+    reloaded = query_service.find_by(id: book.id)
+    expect(reloaded.title).to contain_exactly datetime_rdf
+  end
+
+  # Pending support for RDF::Literal decimal in postgres and solr
+  xit "can handle Decimal RDF properties" do
+    decimal_rdf = RDF::Literal.new(BigDecimal(5.5, 10))
+    book = persister.save(resource: resource_class.new(title: [decimal_rdf]))
+    reloaded = query_service.find_by(id: book.id)
+    expect(reloaded.title).to contain_exactly decimal_rdf
+  end
+
+  # Pending support for RDF::Literal double in postgres and solr
+  xit "can handle Double RDF properties" do
+    double_rdf = RDF::Literal.new(5.5)
+    book = persister.save(resource: resource_class.new(title: [double_rdf]))
+    reloaded = query_service.find_by(id: book.id)
+    expect(reloaded.title).to contain_exactly double_rdf
+  end
+
+  # Pending support for RDF::Literal integer in postgres, solr and fedora
+  xit "can handle Integer RDF properties" do
+    int_rdf = RDF::Literal.new(17)
+    book = persister.save(resource: resource_class.new(title: [int_rdf]))
+    reloaded = query_service.find_by(id: book.id)
+    expect(reloaded.title).to contain_exactly int_rdf
+  end
+
+  it "can handle language-typed RDF properties" do
+    language_rdf = RDF::Literal.new("Test", language: :fr)
+    book = persister.save(resource: resource_class.new(title: ["Test1", language_rdf]))
+    reloaded = query_service.find_by(id: book.id)
+    expect(reloaded.title).to contain_exactly "Test1", language_rdf
+  end
+
+  # Pending support for RDF::Literal time in postgres and solr
+  xit "can handle Time RDF properties" do
+    time_rdf = RDF::Literal.new(Time.current)
+    book = persister.save(resource: resource_class.new(title: [time_rdf]))
+    reloaded = query_service.find_by(id: book.id)
+    expect(reloaded.title).to contain_exactly time_rdf
   end
 
   it "can store Valkyrie::IDs" do


### PR DESCRIPTION
Unfortunately postgres and solr do not support most of the RDF Types, and fedora also does not support some.

fixes #209 

Here is an example of the failure on the test when it is not marked pending:

  1) Valkyrie::Persistence::Postgres::Persister behaves like a Valkyrie::Persister can handle Time RDF properties
     Failure/Error: expect(reloaded.title).to contain_exactly RDF::Literal.new(time)

       expected collection contained:  [#<RDF::Literal::Time:0x3fc2f815d664("09:17:22-05:00"^^<http://www.w3.org/2001/XMLSchema#time>)>]
       actual collection contained:    [#<RDF::Literal:0x3fc2f6942098("09:17:22-05:00")>]
       the missing elements were:      [#<RDF::Literal::Time:0x3fc2f815d664("09:17:22-05:00"^^<http://www.w3.org/2001/XMLSchema#time>)>]
       the extra elements were:        [#<RDF::Literal:0x3fc2f6942098("09:17:22-05:00")>]
     Shared Example Group: "a Valkyrie::Persister" called from ./spec/valkyrie/persistence/postgres/persister_spec.rb:10
     # ./lib/valkyrie/specs/shared_specs/persister.rb:133:in `block (2 levels) in <top (required)>'

  2) Valkyrie::Persistence::Solr::Persister behaves like a Valkyrie::Persister can handle Time RDF properties
     Failure/Error: expect(reloaded.title).to contain_exactly RDF::Literal.new(time)

       expected collection contained:  [#<RDF::Literal::Time:0x3fc2f6e9b968("09:17:23-05:00"^^<http://www.w3.org/2001/XMLSchema#time>)>]
       actual collection contained:    [#<RDF::Literal:0x3fc2f6e9e938("09:17:23-05:00"@)>]
       the missing elements were:      [#<RDF::Literal::Time:0x3fc2f6e9b968("09:17:23-05:00"^^<http://www.w3.org/2001/XMLSchema#time>)>]
       the extra elements were:        [#<RDF::Literal:0x3fc2f6e9e938("09:17:23-05:00"@)>]
     Shared Example Group: "a Valkyrie::Persister" called from ./spec/valkyrie/persistence/solr/persister_spec.rb:10
     # ./lib/valkyrie/specs/shared_specs/persister.rb:133:in `block (2 levels) in <top (required)>'