### PR TITLE
Adding Reform::Form::ModelReflections to ChangeSet class fixes #327

### DIFF
--- a/lib/valkyrie/change_set.rb
+++ b/lib/valkyrie/change_set.rb
@@ -14,6 +14,7 @@ module Valkyrie
   #     property :title, multiple: false, required: true
   #   end
   class ChangeSet < Reform::Form
+    include Reform::Form::ModelReflections
     include Reform::Form::ActiveModel::Validations
     feature Coercion
     class_attribute :fields

--- a/spec/valkyrie/change_set_spec.rb
+++ b/spec/valkyrie/change_set_spec.rb
@@ -19,6 +19,12 @@ RSpec.describe Valkyrie::ChangeSet do
   end
   subject(:change_set) { ResourceChangeSet.new(Resource.new) }
 
+  describe ".validators_on" do
+    it "the class responds to validators_on" do
+      expect(described_class).to respond_to(:validators_on)
+    end
+  end
+
   it "can set an append_id" do
     change_set.append_id = Valkyrie::ID.new("test")
     expect(change_set.append_id).to eq Valkyrie::ID.new("test")


### PR DESCRIPTION
This was done to include validators_on for better integration with simple form.