### PR TITLE
Lock dry-types to < 0.13.0

### DIFF
--- a/valkyrie.gemspec
+++ b/valkyrie.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'dry-struct'
   spec.add_dependency 'draper'
   spec.add_dependency 'activemodel'
-  spec.add_dependency 'dry-types'
+  spec.add_dependency 'dry-types', '~> 0.12.0'
   spec.add_dependency 'rdf'
   spec.add_dependency 'active-fedora'
   spec.add_dependency 'activesupport'


### PR DESCRIPTION
The interface has changed substantially in 0.13.0 and Valkyrie isn't set
up for it yet - will require many deprecation warnings and changes.