### PR TITLE
Always bundle, don't just check.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install -y libpq-dev
       - run:
           name: Install dependencies
-          command: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs 4 --retry 3
+          command: bundle install --path=vendor/bundle --jobs 4 --retry 3
       - save_cache:
           key: bundle-{{ checksum "Gemfile" }}-{{ checksum "valkyrie.gemspec" }}
           paths:

--- a/valkyrie.gemspec
+++ b/valkyrie.gemspec
@@ -50,4 +50,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'solr_wrapper'
   spec.add_development_dependency 'fcrepo_wrapper'
   spec.add_development_dependency 'docker-stack', '~> 0.2.6'
+  spec.add_development_dependency 'activerecord', '~> 5.1.0'
 end


### PR DESCRIPTION
Bundle check will return true even if outdated gems are the only ones
available.

The nightly build should have been failing and wasn't because of this.