### PR TITLE
Loosen pg dependency; rails supports 1.0 in 5.1.5

### DIFF
--- a/valkyrie.gemspec
+++ b/valkyrie.gemspec
@@ -30,9 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'railties' # To use generators and engines
   spec.add_dependency 'reform'
   spec.add_dependency 'reform-rails'
-  # pg 1.0 is not compatable with Rails 5 yet.
-  # https://stackoverflow.com/a/48201362
-  spec.add_dependency 'pg', '< 1.0'
+  spec.add_dependency 'pg'
   spec.add_dependency 'json-ld'
   spec.add_dependency 'json'
   spec.add_dependency 'active-triples'


### PR DESCRIPTION
fixes #440

see https://github.com/rails/rails/blob/v5.1.6/activerecord/CHANGELOG.md#rails-515-february-14-2018