### PR TITLE
Update Dry-Struct/Dry-Types.

### DIFF
--- a/lib/valkyrie/persistence/fedora/persister/model_converter.rb
+++ b/lib/valkyrie/persistence/fedora/persister/model_converter.rb
@@ -132,7 +132,7 @@ module Valkyrie::Persistence::Fedora
       class NestedProperty < ::Valkyrie::ValueMapper
         FedoraValue.register(self)
         def self.handles?(value)
-          value.is_a?(Property) && value.value.is_a?(Hash) && value.value[:internal_resource]
+          value.is_a?(Property) && (value.value.is_a?(Hash) || value.value.is_a?(Valkyrie::Resource)) && value.value[:internal_resource]
         end
 
         def result

--- a/lib/valkyrie/persistence/memory/query_service.rb
+++ b/lib/valkyrie/persistence/memory/query_service.rb
@@ -32,7 +32,7 @@ module Valkyrie::Persistence::Memory
     def find_by_alternate_identifier(alternate_identifier:)
       alternate_identifier = Valkyrie::ID.new(alternate_identifier.to_s) if alternate_identifier.is_a?(String)
       validate_id(alternate_identifier)
-      cache.select { |_key, resource| resource['alternate_ids'].include?(alternate_identifier) }.values.first || raise(::Valkyrie::Persistence::ObjectNotFoundError)
+      cache.select { |_key, resource| resource[:alternate_ids].include?(alternate_identifier) }.values.first || raise(::Valkyrie::Persistence::ObjectNotFoundError)
     end
 
     # @param ids [Array<Valkyrie::ID, String>] The IDs to query for.

--- a/lib/valkyrie/persistence/solr/model_converter.rb
+++ b/lib/valkyrie/persistence/solr/model_converter.rb
@@ -146,7 +146,7 @@ module Valkyrie::Persistence::Solr
       class NestedObjectValue < ::Valkyrie::ValueMapper
         SolrMapperValue.register(self)
         def self.handles?(value)
-          value.value.is_a?(Hash)
+          value.value.is_a?(Hash) || value.value.is_a?(Valkyrie::Resource)
         end
 
         def result

--- a/lib/valkyrie/types.rb
+++ b/lib/valkyrie/types.rb
@@ -77,7 +77,17 @@ module Valkyrie
       end
 
       def member(type)
-        super.default([].freeze)
+        warn "[DEPRECATION] .member has been removed by dry-types and will be removed in the next " \
+             "major version of Valkyrie. Please use .of instead. " \
+             "Called from #{Gem.location_of_caller.join(':')}"
+        of(type).default([].freeze)
+      end
+
+      # Override optional to provide a default because without it an
+      # instantiated Valkyrie::Resource's internal hash does not have values for
+      # every possible attribute, resulting in `MissingAttributeError`.
+      def optional
+        super.default(nil)
       end
     end
     Array.singleton_class.include(ArrayDefault)

--- a/spec/valkyrie/resource_spec.rb
+++ b/spec/valkyrie/resource_spec.rb
@@ -18,6 +18,29 @@ RSpec.describe Valkyrie::Resource do
     end
   end
 
+  describe ".constructor_type" do
+    it "throws a deprecation warning" do
+      allow(Resource).to receive(:warn)
+
+      Resource.constructor_type :schema
+      expect(Resource).to have_received(:warn)
+    end
+  end
+
+  describe "[]" do
+    it "works as an accessor for properties" do
+      expect(resource[:title]).to eq []
+    end
+    it "throws a deprecation warning if accessed via a string" do
+      # rubocop:disable RSpec/SubjectStub
+      allow(resource).to receive(:warn)
+      # rubocop:enable RSpec/SubjectStub
+      expect(resource["title"]).to eq []
+
+      expect(resource).to have_received(:warn)
+    end
+  end
+
   describe "#has_attribute?" do
     it "returns true for fields that exist" do
       expect(resource.has_attribute?(:title)).to eq true

--- a/spec/valkyrie/types_spec.rb
+++ b/spec/valkyrie/types_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe Valkyrie::Types do
       attribute :authors, Valkyrie::Types::Array
       attribute :geonames_uri, Valkyrie::Types::URI
       attribute :thumbnail_id, Valkyrie::Types::ID
-      attribute :embargo_release_date, Valkyrie::Types::Set.member(Valkyrie::Types::DateTime).optional
+      attribute :embargo_release_date, Valkyrie::Types::Set.of(Valkyrie::Types::DateTime).optional
       attribute :set_of_values, Valkyrie::Types::Set
       attribute :my_flag, Valkyrie::Types::Bool
       attribute :nested_resource_array, Valkyrie::Types::Array.member(Resource.optional)
       attribute :nested_resource_array_of, Valkyrie::Types::Array.of(Resource.optional)
-      attribute :nested_resource_set, Valkyrie::Types::Set.member(Resource.optional)
+      attribute :nested_resource_set, Valkyrie::Types::Set.of(Resource.optional)
     end
   end
   after do

--- a/valkyrie.gemspec
+++ b/valkyrie.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'dry-struct'
   spec.add_dependency 'draper'
   spec.add_dependency 'activemodel'
-  spec.add_dependency 'dry-types', '~> 0.12.0'
+  spec.add_dependency 'dry-types', '~> 0.13.0'
   spec.add_dependency 'rdf'
   spec.add_dependency 'active-fedora'
   spec.add_dependency 'activesupport'


### PR DESCRIPTION
This should add all the necessary back-ports to prevent having to
release a major version of Valkyrie, but still support the latest
dry-types and dry-struct.