### PR TITLE
Add enable_optimistic_locking on Valkyrie::Resource

### DIFF
--- a/lib/valkyrie/resource.rb
+++ b/lib/valkyrie/resource.rb
@@ -62,6 +62,10 @@ module Valkyrie
       @_human_readable_type = val
     end
 
+    def self.enable_optimistic_locking
+      attribute(:optimistic_lock_token, Valkyrie::Types::Set)
+    end
+
     # @return [Hash] Hash of attributes
     def attributes
       to_h

--- a/spec/valkyrie/resource_spec.rb
+++ b/spec/valkyrie/resource_spec.rb
@@ -101,4 +101,41 @@ RSpec.describe Valkyrie::Resource do
       end
     end
   end
+
+  describe "::enable_optimistic_locking" do
+    context "when it is enabled" do
+      before do
+        class MyLockingResource < Valkyrie::Resource
+          enable_optimistic_locking
+          attribute :id, Valkyrie::Types::ID.optional
+          attribute :title, Valkyrie::Types::Set
+        end
+      end
+
+      after do
+        Object.send(:remove_const, :MyLockingResource)
+      end
+
+      it "has an optimistic_lock_token attribute" do
+        expect(MyLockingResource.new).to respond_to(:optimistic_lock_token)
+      end
+    end
+
+    context "when it is not enabled" do
+      before do
+        class MyNonlockingResource < Valkyrie::Resource
+          attribute :id, Valkyrie::Types::ID.optional
+          attribute :title, Valkyrie::Types::Set
+        end
+      end
+
+      after do
+        Object.send(:remove_const, :MyNonlockingResource)
+      end
+
+      it "does not have an optimistic_lock_token attribute" do
+        expect(MyNonlockingResource.new).not_to respond_to(:optimistic_lock_token)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #452 

Adds a property to resource that will enable optimistic locking for each persister.