### PR TITLE
Add optimistic locking attribute to Solr persister

### DIFF
--- a/lib/valkyrie/persistence.rb
+++ b/lib/valkyrie/persistence.rb
@@ -37,6 +37,8 @@ module Valkyrie
     end
     class UnsupportedDatatype < StandardError
     end
+    class StaleObjectError < StandardError
+    end
 
     module Attributes
       OPTIMISTIC_LOCK = :optimistic_lock_token

--- a/lib/valkyrie/persistence/solr/model_converter.rb
+++ b/lib/valkyrie/persistence/solr/model_converter.rb
@@ -40,7 +40,7 @@ module Valkyrie::Persistence::Solr
         "id": id,
         "join_id_ssi": "id-#{id}",
         "created_at_dtsi": created_at
-      }.merge(add_single_values(attribute_hash))
+      }.merge(add_single_values(attribute_hash)).merge(lock_hash)
     end
 
     private
@@ -58,6 +58,15 @@ module Valkyrie::Persistence::Solr
 
       def multivalued?(field)
         field.end_with?('m', 'mv')
+      end
+
+      def lock_hash
+        return {} unless resource.optimistic_locking_enabled? && lock_token.present?
+        { _version_: lock_token }
+      end
+
+      def lock_token
+        @lock_token ||= resource.send(Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK).first
       end
 
       def attribute_hash

--- a/lib/valkyrie/resource.rb
+++ b/lib/valkyrie/resource.rb
@@ -66,6 +66,10 @@ module Valkyrie
       attribute(Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK, Valkyrie::Types::Set)
     end
 
+    def optimistic_locking_enabled?
+      respond_to?(Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK)
+    end
+
     # @return [Hash] Hash of attributes
     def attributes
       to_h

--- a/lib/valkyrie/specs/shared_specs/locking_persister.rb
+++ b/lib/valkyrie/specs/shared_specs/locking_persister.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+RSpec.shared_examples 'a Valkyrie locking persister' do
+  before do
+    class MyLockingResource < Valkyrie::Resource
+      enable_optimistic_locking
+      attribute :id, Valkyrie::Types::ID.optional
+      attribute :title
+    end
+  end
+
+  after do
+    ActiveSupport::Dependencies.remove_constant("MyLockingResource")
+  end
+
+  describe "#save" do
+    context "when creating a resource" do
+      it "returns the value of the system-generated optimistic locking attribute on the resource" do
+        resource = MyLockingResource.new(title: ["My Locked Resource"])
+        saved_resource = persister.save(resource: resource)
+        expect(saved_resource.send(Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK)).not_to be_empty
+      end
+    end
+
+    context "when updating a resource with a correct lock token" do
+      it "successfully saves the resource and returns the updated value of the optimistic locking attribute" do
+        resource = MyLockingResource.new(title: ["My Locked Resource"])
+        initial_resource = persister.save(resource: resource)
+        updated_resource = persister.save(resource: initial_resource)
+        expect(initial_resource.send(Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK))
+          .not_to eq updated_resource.send(Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK)
+      end
+    end
+
+    context "when updating a resource with an incorrect lock token" do
+      it "raises a Valkyrie::Persistence::StaleObjectError" do
+        resource = MyLockingResource.new(title: ["My Locked Resource"])
+        resource = persister.save(resource: resource)
+        # update the resource in the datastore to make its token stale
+        persister.save(resource: resource)
+
+        expect { persister.save(resource: resource) }.to raise_error(Valkyrie::Persistence::StaleObjectError, resource.id.to_s)
+      end
+    end
+
+    context "when lock token is nil" do
+      it "successfully saves the resource and returns the updated value of the optimistic locking attribute" do
+        resource = MyLockingResource.new(title: ["My Locked Resource"])
+        initial_resource = persister.save(resource: resource)
+        initial_token = initial_resource.send(Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK)
+        initial_resource.send("#{Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK}=", [])
+        updated_resource = persister.save(resource: initial_resource)
+        expect(initial_token).not_to eq updated_resource.send(Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK)
+        expect(updated_resource.send(Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK)).not_to be_empty
+      end
+    end
+  end
+
+  describe "#save_all" do
+    context "when creating multiple resources" do
+      it "returns an array of resources with their system-generated optimistic locking attributes" do
+        resource1 = MyLockingResource.new(title: ["My Locked Resource 1"])
+        resource2 = MyLockingResource.new(title: ["My Locked Resource 2"])
+        resource3 = MyLockingResource.new(title: ["My Locked Resource 3"])
+        saved_resources = persister.save_all(resources: [resource1, resource2, resource3])
+        saved_resources.each do |saved_resource|
+          expect(saved_resource.send(Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK)).not_to be_empty
+        end
+      end
+    end
+
+    context "when updating multiple resources that all have a correct lock token" do
+      it "saves the resources and returns them with updated values of the optimistic locking attribute" do
+        resource1 = MyLockingResource.new(title: ["My Locked Resource 1"])
+        resource2 = MyLockingResource.new(title: ["My Locked Resource 2"])
+        resource3 = MyLockingResource.new(title: ["My Locked Resource 3"])
+        saved_resources = persister.save_all(resources: [resource1, resource2, resource3])
+        initial_lock_tokens = saved_resources.map do |r|
+          r.send(Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK)
+        end
+        updated_resources = persister.save_all(resources: saved_resources)
+        updated_lock_tokens = updated_resources.map do |r|
+          r.send(Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK)
+        end
+        expect(initial_lock_tokens & updated_lock_tokens).to be_empty
+      end
+    end
+
+    context "when one of the resources has an incorrect lock token" do
+      it "raises a Valkyrie::Persistence::StaleObjectError" do
+        resource1 = MyLockingResource.new(title: ["My Locked Resource 1"])
+        resource2 = MyLockingResource.new(title: ["My Locked Resource 2"])
+        resource3 = MyLockingResource.new(title: ["My Locked Resource 3"])
+        resource1, resource2, resource3 = persister.save_all(resources: [resource1, resource2, resource3])
+        # update a resource in the datastore to make its token stale
+        persister.save(resource: resource2)
+
+        expect { persister.save_all(resources: [resource1, resource2, resource3]) }
+          .to raise_error(Valkyrie::Persistence::StaleObjectError, [resource1, resource2, resource3].map(&:id).join(", "))
+      end
+    end
+  end
+end

--- a/spec/valkyrie/persistence/solr/model_converter_spec.rb
+++ b/spec/valkyrie/persistence/solr/model_converter_spec.rb
@@ -32,6 +32,9 @@ RSpec.describe Valkyrie::Persistence::Solr::ModelConverter do
                       creator: "Creator"
                     })
   end
+  before do
+    allow(resource).to receive(:optimistic_locking_enabled?).and_return(false)
+  end
 
   describe "#to_h" do
     it "maps all available properties to the solr record" do

--- a/spec/valkyrie/persistence/solr/persister_spec.rb
+++ b/spec/valkyrie/persistence/solr/persister_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 require 'valkyrie/specs/shared_specs'
+require 'valkyrie/specs/shared_specs/locking_persister'
 
 RSpec.describe Valkyrie::Persistence::Solr::Persister do
   let(:query_service) { adapter.query_service }
@@ -8,6 +9,7 @@ RSpec.describe Valkyrie::Persistence::Solr::Persister do
   let(:adapter) { Valkyrie::Persistence::Solr::MetadataAdapter.new(connection: client) }
   let(:client) { RSolr.connect(url: SOLR_TEST_URL) }
   it_behaves_like "a Valkyrie::Persister"
+  it_behaves_like "a Valkyrie locking persister"
 
   context "when given additional persisters" do
     let(:adapter) { Valkyrie::Persistence::Solr::MetadataAdapter.new(connection: client, resource_indexer: indexer) }
@@ -74,6 +76,31 @@ RSpec.describe Valkyrie::Persistence::Solr::Persister do
       reloaded = query_service.find_by(id: book.id)
 
       expect(reloaded.title.first[0, 19]).to eq("datetime-#{time1.to_s[0, 10]}")
+    end
+  end
+
+  describe "#save" do
+    # supplement specs from shared_specs/locking_persister with a solr-specific test
+    # The only error we catch is the 409 conflict
+    context "when updating a resource with an invalid token" do
+      before do
+        class MyLockingResource < Valkyrie::Resource
+          enable_optimistic_locking
+          attribute :id, Valkyrie::Types::ID.optional
+          attribute :title
+        end
+      end
+
+      after do
+        ActiveSupport::Dependencies.remove_constant("MyLockingResource")
+      end
+
+      it "raises an Rsolr 500 Error" do
+        resource = MyLockingResource.new(title: ["My Locked Resource"])
+        initial_resource = persister.save(resource: resource)
+        initial_resource.send("#{Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK}=", ["NOT_EVEN_A_VALID_TOKEN"])
+        expect { persister.save(resource: initial_resource) }.to raise_error(RSolr::Error::Http)
+      end
     end
   end
 end

--- a/spec/valkyrie/resource_spec.rb
+++ b/spec/valkyrie/resource_spec.rb
@@ -118,6 +118,7 @@ RSpec.describe Valkyrie::Resource do
 
       it "has an optimistic_lock_token attribute" do
         expect(MyLockingResource.new).to respond_to(Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK)
+        expect(MyLockingResource.new.optimistic_locking_enabled?).to be true
       end
     end
 
@@ -135,6 +136,7 @@ RSpec.describe Valkyrie::Resource do
 
       it "does not have an optimistic_lock_token attribute" do
         expect(MyNonlockingResource.new).not_to respond_to(:optimistic_lock_token)
+        expect(MyNonlockingResource.new.optimistic_locking_enabled?).to be false
       end
     end
   end


### PR DESCRIPTION
Fixes #453 

Adds the optimistic locking attribute to the Solr persister so that `_version_` is added and return from update requests.