### PR TITLE
Use `of` instead of `member`.

### DIFF
--- a/spec/valkyrie/types_spec.rb
+++ b/spec/valkyrie/types_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe Valkyrie::Types do
       attribute :authors, Valkyrie::Types::Array
       attribute :geonames_uri, Valkyrie::Types::URI
       attribute :thumbnail_id, Valkyrie::Types::ID
-      attribute :embargo_release_date, Valkyrie::Types::Set.member(Valkyrie::Types::DateTime).optional
+      attribute :embargo_release_date, Valkyrie::Types::Set.of(Valkyrie::Types::DateTime).optional
       attribute :set_of_values, Valkyrie::Types::Set
       attribute :my_flag, Valkyrie::Types::Bool
-      attribute :nested_resource_array, Valkyrie::Types::Array.member(Resource.optional)
+      attribute :nested_resource_array, Valkyrie::Types::Array.of(Resource.optional)
       attribute :nested_resource_array_of, Valkyrie::Types::Array.of(Resource.optional)
-      attribute :nested_resource_set, Valkyrie::Types::Set.member(Resource.optional)
+      attribute :nested_resource_set, Valkyrie::Types::Set.of(Resource.optional)
     end
   end
   after do

--- a/spec/valkyrie/types_spec.rb
+++ b/spec/valkyrie/types_spec.rb
@@ -87,6 +87,9 @@ RSpec.describe Valkyrie::Types do
       resource = Resource.new(authors: {})
       expect(resource.authors).to eq []
     end
+    it "can use .member" do
+      expect { Valkyrie::Types::Array.member(Valkyrie::Types::String) }.not_to raise_error
+    end
   end
 
   describe "the DateTime type" do
@@ -112,6 +115,9 @@ RSpec.describe Valkyrie::Types do
     it "returns an empty array if given an empty hash" do
       resource = Resource.new(set_of_values: {})
       expect(resource.set_of_values).to eq []
+    end
+    it "can use .member" do
+      expect { Valkyrie::Types::Set.member(Valkyrie::Types::String) }.not_to raise_error
     end
   end
 


### PR DESCRIPTION
It's been deprecated. `member` still works for now, but when we
upgrade...

Closes #413