### PR TITLE
Inherited classes now properly re-scheme attrs.

### DIFF
--- a/spec/valkyrie/resource_spec.rb
+++ b/spec/valkyrie/resource_spec.rb
@@ -99,6 +99,17 @@ RSpec.describe Valkyrie::Resource do
         expect(MyResource.fields).to eq [:id, :internal_resource, :created_at, :updated_at, :title]
       end
     end
+    describe "#internal_resource" do
+      it "returns a stringified version of itself" do
+        expect(MyResource.new.internal_resource).to eq "MyResource"
+      end
+    end
+    describe "defining an internal attribute" do
+      it "warns you and doesn't change the type" do
+        expect { MyResource.attribute(:id) }.to output(/is a reserved attribute/).to_stderr
+        expect(MyResource.schema[:id].right).to eq Valkyrie::Types::ID
+      end
+    end
   end
 
   describe "::enable_optimistic_locking" do


### PR DESCRIPTION
https://github.com/samvera-labs/valkyrie/pull/500 broke inheritance for upstream applications, resulting in all
`internal_resource` values being equal to ['Resource']. This fixes that.