### PR TITLE
Use #connection_config to generate postgres ID

### DIFF
--- a/lib/valkyrie/persistence/postgres/metadata_adapter.rb
+++ b/lib/valkyrie/persistence/postgres/metadata_adapter.rb
@@ -28,7 +28,7 @@ module Valkyrie::Persistence::Postgres
 
     def id
       @id ||= begin
-        to_hash = "#{resource_factory.orm_class.configurations[ENV['RAILS_ENV']]['host']}:#{resource_factory.orm_class.configurations[ENV['RAILS_ENV']]['database']}"
+        to_hash = "#{resource_factory.orm_class.connection_config['host']}:#{resource_factory.orm_class.connection_config['database']}"
         Valkyrie::ID.new(Digest::MD5.hexdigest(to_hash))
       end
     end

--- a/spec/valkyrie/persistence/postgres/metadata_adapter_spec.rb
+++ b/spec/valkyrie/persistence/postgres/metadata_adapter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Valkyrie::Persistence::Postgres::MetadataAdapter do
 
   describe "#id" do
     it "creates an md5 hash from the host and database name" do
-      to_hash = "#{ActiveRecord::Base.configurations[ENV['RAILS_ENV']]['host']}:#{ActiveRecord::Base.configurations[ENV['RAILS_ENV']]['database']}"
+      to_hash = "#{ActiveRecord::Base.connection_config['host']}:#{ActiveRecord::Base.connection_config['database']}"
       expected = Digest::MD5.hexdigest to_hash
       expect(adapter.id.to_s).to eq expected
     end


### PR DESCRIPTION
Figgy was having trouble using the previous access method, and this
delegates figuring out the environment to ActiveRecord which seems more
appropriate anyways.