### PR TITLE
Allow users to override built in attributes.

### DIFF
--- a/lib/valkyrie/resource.rb
+++ b/lib/valkyrie/resource.rb
@@ -39,11 +39,13 @@ module Valkyrie
     # @param type [Dry::Types::Type]
     # @note Overridden from {Dry::Struct} to make the default type
     #   {Valkyrie::Types::Set}
+    # @todo Remove ability to override built in attributes.
     def self.attribute(name, type = Valkyrie::Types::Set.optional, internal: false)
       if reserved_attributes.include?(name.to_sym) && schema[name] && !internal
         warn "#{name} is a reserved attribute in Valkyrie::Resource and defined by it. You can remove your definition of `attribute :#{name}`. " \
+             "For now your version will be used, but in the next major version the type will be overridden. " \
              "Called from #{Gem.location_of_caller.join(':')}"
-        return
+        schema.delete(name)
       end
       define_method("#{name}=") do |value|
         instance_variable_set("@#{name}", self.class.schema[name].call(value))

--- a/spec/valkyrie/resource_spec.rb
+++ b/spec/valkyrie/resource_spec.rb
@@ -105,9 +105,9 @@ RSpec.describe Valkyrie::Resource do
       end
     end
     describe "defining an internal attribute" do
-      it "warns you and doesn't change the type" do
+      it "warns you and changes the type" do
         expect { MyResource.attribute(:id) }.to output(/is a reserved attribute/).to_stderr
-        expect(MyResource.schema[:id].right).to eq Valkyrie::Types::ID
+        expect(MyResource.schema[:id]).to eq Valkyrie::Types::Set.optional
       end
     end
   end


### PR DESCRIPTION
This fixes a breaking change introduced by #500 and sends a deprecation
warning to warn users that it won't allow overriding the type in the
future.