### PR TITLE
Optimistic Locking for Postgres

### DIFF
--- a/db/migrate/20180802220739_add_optimistic_locking_to_orm_resources.rb
+++ b/db/migrate/20180802220739_add_optimistic_locking_to_orm_resources.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddOptimisticLockingToOrmResources < ActiveRecord::Migration[5.1]
+  def change
+    add_column :orm_resources, :lock_version, :integer
+  end
+end

--- a/lib/valkyrie/persistence/postgres/metadata_adapter.rb
+++ b/lib/valkyrie/persistence/postgres/metadata_adapter.rb
@@ -23,7 +23,7 @@ module Valkyrie::Persistence::Postgres
 
     # @return [Class] {Valkyrie::Persistence::Postgres::ResourceFactory}
     def resource_factory
-      Valkyrie::Persistence::Postgres::ResourceFactory
+      @resource_factory ||= Valkyrie::Persistence::Postgres::ResourceFactory.new(adapter: self)
     end
 
     def id

--- a/lib/valkyrie/persistence/postgres/persister.rb
+++ b/lib/valkyrie/persistence/postgres/persister.rb
@@ -15,6 +15,8 @@ module Valkyrie::Persistence::Postgres
       orm_object = resource_factory.from_resource(resource: resource)
       orm_object.save!
       resource_factory.to_resource(object: orm_object)
+    rescue ActiveRecord::StaleObjectError
+      raise Valkyrie::Persistence::StaleObjectError, resource.id.to_s
     end
 
     # (see Valkyrie::Persistence::Memory::Persister#save_all)
@@ -24,6 +26,8 @@ module Valkyrie::Persistence::Postgres
           save(resource: resource)
         end
       end
+    rescue Valkyrie::Persistence::StaleObjectError
+      raise Valkyrie::Persistence::StaleObjectError, resources.map(&:id).join(", ")
     end
 
     # (see Valkyrie::Persistence::Memory::Persister#delete)

--- a/lib/valkyrie/persistence/postgres/resource_converter.rb
+++ b/lib/valkyrie/persistence/postgres/resource_converter.rb
@@ -13,8 +13,18 @@ module Valkyrie::Persistence::Postgres
     def convert!
       orm_class.find_or_initialize_by(id: resource.id && resource.id.to_s).tap do |orm_object|
         orm_object.internal_resource = resource.internal_resource
+        process_lock_token(orm_object)
         orm_object.metadata.merge!(attributes)
       end
+    end
+
+    def process_lock_token(orm_object)
+      return unless resource.respond_to?(Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK)
+      postgres_token = resource[Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK].find do |token|
+        token.adapter_id == resource_factory.adapter_id
+      end
+      return unless postgres_token
+      orm_object.lock_version = postgres_token.token
     end
 
     # Convert attributes to all be arrays to better enable querying and

--- a/lib/valkyrie/persistence/postgres/resource_factory.rb
+++ b/lib/valkyrie/persistence/postgres/resource_factory.rb
@@ -5,26 +5,30 @@ module Valkyrie::Persistence::Postgres
   # Provides access to generic methods for converting to/from
   # {Valkyrie::Resource} and {Valkyrie::Persistence::Postgres::ORM::Resource}.
   class ResourceFactory
-    class << self
-      # @param object [Valkyrie::Persistence::Postgres::ORM::Resource] AR
-      #   record to be converted.
-      # @return [Valkyrie::Resource] Model representation of the AR record.
-      def to_resource(object:)
-        ::Valkyrie::Persistence::Postgres::ORMConverter.new(object).convert!
-      end
+    attr_reader :adapter
+    delegate :id, to: :adapter, prefix: true
+    def initialize(adapter:)
+      @adapter = adapter
+    end
 
-      # @param resource [Valkyrie::Resource] Model to be converted to ActiveRecord.
-      # @return [Valkyrie::Persistence::Postgres::ORM::Resource] ActiveRecord
-      #   resource for the Valkyrie resource.
-      def from_resource(resource:)
-        ::Valkyrie::Persistence::Postgres::ResourceConverter.new(resource, resource_factory: self).convert!
-      end
+    # @param object [Valkyrie::Persistence::Postgres::ORM::Resource] AR
+    #   record to be converted.
+    # @return [Valkyrie::Resource] Model representation of the AR record.
+    def to_resource(object:)
+      ::Valkyrie::Persistence::Postgres::ORMConverter.new(object, resource_factory: self).convert!
+    end
 
-      # Accessor for the ActiveRecord class which all Postgres resources are an
-      # instance of.
-      def orm_class
-        ::Valkyrie::Persistence::Postgres::ORM::Resource
-      end
+    # @param resource [Valkyrie::Resource] Model to be converted to ActiveRecord.
+    # @return [Valkyrie::Persistence::Postgres::ORM::Resource] ActiveRecord
+    #   resource for the Valkyrie resource.
+    def from_resource(resource:)
+      ::Valkyrie::Persistence::Postgres::ResourceConverter.new(resource, resource_factory: self).convert!
+    end
+
+    # Accessor for the ActiveRecord class which all Postgres resources are an
+    # instance of.
+    def orm_class
+      ::Valkyrie::Persistence::Postgres::ORM::Resource
     end
   end
 end

--- a/lib/valkyrie/resource.rb
+++ b/lib/valkyrie/resource.rb
@@ -77,8 +77,12 @@ module Valkyrie
       attribute(Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK, Valkyrie::Types::Set.of(Valkyrie::Types::OptimisticLockToken))
     end
 
+    def self.optimistic_locking_enabled?
+      schema.key?(Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK)
+    end
+
     def optimistic_locking_enabled?
-      respond_to?(Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK)
+      self.class.optimistic_locking_enabled?
     end
 
     # @return [Hash] Hash of attributes

--- a/spec/valkyrie/persistence/postgres/query_service_spec.rb
+++ b/spec/valkyrie/persistence/postgres/query_service_spec.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 require 'spec_helper'
 require 'valkyrie/specs/shared_specs'
+require 'valkyrie/specs/shared_specs/locking_query'
 
 RSpec.describe Valkyrie::Persistence::Postgres::QueryService do
   let(:adapter) { Valkyrie::Persistence::Postgres::MetadataAdapter.new }
   it_behaves_like "a Valkyrie query provider"
+  it_behaves_like "a Valkyrie locking query provider"
 end

--- a/spec/valkyrie/resource_spec.rb
+++ b/spec/valkyrie/resource_spec.rb
@@ -130,6 +130,7 @@ RSpec.describe Valkyrie::Resource do
 
         expect(resource).to respond_to(Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK)
         expect(resource.optimistic_locking_enabled?).to be true
+        expect(resource.class.optimistic_locking_enabled?).to be true
       end
 
       describe ".#{Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK}" do
@@ -165,6 +166,7 @@ RSpec.describe Valkyrie::Resource do
       it "does not have an optimistic_lock_token attribute" do
         expect(MyNonlockingResource.new).not_to respond_to(:optimistic_lock_token)
         expect(MyNonlockingResource.new.optimistic_locking_enabled?).to be false
+        expect(MyNonlockingResource.optimistic_locking_enabled?).to be false
       end
     end
   end


### PR DESCRIPTION
Closes #456.
Closes #459.

This is ready for review, but it needs to be rebased on master after #510 is merged.

I've confirmed that this PR works on Figgy -without- running the database migration.