### PR TITLE
Change composite persister to duplicate cached resource

### DIFF
--- a/lib/valkyrie/persistence/composite_persister.rb
+++ b/lib/valkyrie/persistence/composite_persister.rb
@@ -23,7 +23,7 @@ module Valkyrie::Persistence
       first, *rest = *persisters
       cached_resource = first.save(resource: resource)
       # Don't pass opt lock tokens to other persisters
-      internal_resource = resource.dup
+      internal_resource = cached_resource.dup
       internal_resource.send("#{Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK}=", []) if internal_resource.optimistic_locking_enabled?
       rest.inject(internal_resource) { |m, persister| persister.save(resource: m) }
       # return the one with the desired opt lock token

--- a/spec/valkyrie/persistence/composite_persister_spec.rb
+++ b/spec/valkyrie/persistence/composite_persister_spec.rb
@@ -12,4 +12,28 @@ RSpec.describe Valkyrie::Persistence::CompositePersister do
     )
   end
   it_behaves_like "a Valkyrie::Persister"
+
+  context 'with postgres and solr' do
+    let(:client) { RSolr.connect(url: SOLR_TEST_URL) }
+    let(:persister) do
+      described_class.new(
+        Valkyrie::Persistence::Postgres::MetadataAdapter.new.persister,
+        adapter.persister
+      )
+    end
+    let(:adapter) { Valkyrie::Persistence::Solr::MetadataAdapter.new(connection: client) }
+
+    before do
+      class CustomResource < Valkyrie::Resource
+      end
+    end
+    after do
+      Object.send(:remove_const, :CustomResource)
+    end
+
+    it "can find the object in the solr persister" do
+      book = persister.save(resource: CustomResource.new)
+      expect { query_service.find_by(id: book.id) }.not_to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
+    end
+  end
 end


### PR DESCRIPTION
So it is saved when the next persister looks for it. This could only be
tested with some non-memory adapters.