### PR TITLE
Removes ActiveFedora from the storage persister

### DIFF
--- a/spec/valkyrie/storage/fedora_spec.rb
+++ b/spec/valkyrie/storage/fedora_spec.rb
@@ -1,15 +1,20 @@
 # frozen_string_literal: true
 require 'spec_helper'
 require 'valkyrie/specs/shared_specs'
-require 'active_fedora/cleaner'
 include ActionDispatch::TestProcess
 
 RSpec.describe Valkyrie::Storage::Fedora do
   before(:all) do
     # Start from a clean fedora
-    ActiveFedora::Cleaner.clean!
+    Valkyrie::Persistence::Fedora::MetadataAdapter.new(
+      connection: ::Ldp::Client.new("http://localhost:8988/rest"),
+      base_path: "test"
+    ).persister.wipe!
   end
-  it_behaves_like "a Valkyrie::StorageAdapter"
-  let(:storage_adapter) { described_class.new(connection: ActiveFedora.fedora.connection) }
+
+  let(:connection) { ::Ldp::Client.new("http://localhost:8988/rest/test") }
+  let(:storage_adapter) { described_class.new(connection: connection) }
   let(:file) { fixture_file_upload('files/example.tif', 'image/tiff') }
+
+  it_behaves_like "a Valkyrie::StorageAdapter"
 end


### PR DESCRIPTION
Fixes #315 

Pass an Ldp::Client to the storage adapter, just like we do with the metadata adapter.

Not sure if `IOProxy` is still needed. We also aren't getting any metadata back from `fcr:metadata` because I think `AF::File` wrapped that. We could think about our own file object to do that if needed.