### PR TITLE
Using Fedora's If-Unmodified-Since header to prevent clobbering another client's writes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1,5 +1,6 @@
 Metrics/ClassLength:
   Exclude:
+    - 'lib/valkyrie/persistence/fedora/persister.rb'
     - 'lib/valkyrie/persistence/postgres/query_service.rb'
 
 Metrics/MethodLength:

--- a/lib/valkyrie/persistence/fedora/persister.rb
+++ b/lib/valkyrie/persistence/fedora/persister.rb
@@ -28,7 +28,7 @@ module Valkyrie::Persistence::Fedora
       else
         orm.create
       end
-      persisted_resource = resource_factory.to_resource(object: orm, optimistic_locking_enabled: internal_resource.optimistic_locking_enabled?)
+      persisted_resource = resource_factory.to_resource(object: orm)
 
       alternate_resources ? save_reference_to_resource(persisted_resource, alternate_resources) : persisted_resource
     rescue Ldp::PreconditionFailed

--- a/lib/valkyrie/persistence/fedora/persister/model_converter.rb
+++ b/lib/valkyrie/persistence/fedora/persister/model_converter.rb
@@ -22,6 +22,8 @@ module Valkyrie::Persistence::Fedora
         graph_resource
       end
 
+      # Filter resource properties to remove properties that should not be persisted to Fedora.
+      # * new_record is a virtual property for marking unsaved objects
       def properties
         resource_attributes.keys - [:new_record]
       end

--- a/lib/valkyrie/persistence/fedora/persister/orm_converter.rb
+++ b/lib/valkyrie/persistence/fedora/persister/orm_converter.rb
@@ -5,19 +5,35 @@ module Valkyrie::Persistence::Fedora
     class OrmConverter
       attr_reader :object, :adapter
       delegate :graph, to: :object
-      def initialize(object:, adapter:)
+
+      # @note Passing the `optimistic_locking_enabled` value to trigger making Fedora's lastModified property
+      # available for optimistic locking at the persister level.
+      def initialize(object:, adapter:, optimistic_locking_enabled: false)
         @object = object
         @adapter = adapter
+        @optimistic_locking_enabled = optimistic_locking_enabled
       end
 
       def convert
-        Valkyrie::Types::Anything[attributes]
+        resource = Valkyrie::Types::Anything[attributes]
+        populate_native_lock(resource)
+        resource
       end
 
       def attributes
         GraphToAttributes.new(graph: graph, adapter: adapter)
                          .convert
                          .merge(id: id, new_record: false)
+      end
+
+      # Get Fedora's lastModified value from the LDP response
+      def populate_native_lock(resource)
+        return unless @optimistic_locking_enabled
+        lastmod = object.response_graph.first_object([nil, RDF::URI("http://fedora.info/definitions/v4/repository#lastModified"), nil])
+        return unless lastmod
+
+        token = Valkyrie::Persistence::OptimisticLockToken.new(adapter_id: "native-#{adapter.id}", token: DateTime.parse(lastmod.to_s).httpdate)
+        resource.optimistic_lock_token << token
       end
 
       def id

--- a/lib/valkyrie/persistence/fedora/persister/resource_factory.rb
+++ b/lib/valkyrie/persistence/fedora/persister/resource_factory.rb
@@ -15,10 +15,8 @@ module Valkyrie::Persistence::Fedora
         ModelConverter.new(resource: resource, adapter: adapter).convert
       end
 
-      # @note Passing the `optimistic_locking_enabled` value to trigger making Fedora's lastModified property
-      # available for optimistic locking at the persister level.
-      def to_resource(object:, optimistic_locking_enabled: false)
-        OrmConverter.new(object: object, adapter: adapter, optimistic_locking_enabled: optimistic_locking_enabled).convert
+      def to_resource(object:)
+        OrmConverter.new(object: object, adapter: adapter).convert
       end
     end
   end

--- a/lib/valkyrie/persistence/fedora/persister/resource_factory.rb
+++ b/lib/valkyrie/persistence/fedora/persister/resource_factory.rb
@@ -15,8 +15,10 @@ module Valkyrie::Persistence::Fedora
         ModelConverter.new(resource: resource, adapter: adapter).convert
       end
 
-      def to_resource(object:)
-        OrmConverter.new(object: object, adapter: adapter).convert
+      # @note Passing the `optimistic_locking_enabled` value to trigger making Fedora's lastModified property
+      # available for optimistic locking at the persister level.
+      def to_resource(object:, optimistic_locking_enabled: false)
+        OrmConverter.new(object: object, adapter: adapter, optimistic_locking_enabled: optimistic_locking_enabled).convert
       end
     end
   end


### PR DESCRIPTION
Adding a second lock token for Fedora to hold the system-managed fedora:lastModified value, for use with the `If-Unmodified-Since` header.

Fixes #522
Alternative to #531 