### PR TITLE
Remove ActiveFedora from the documentation and test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Rails.application.config.to_prepare do
   )
 
   Valkyrie::StorageAdapter.register(
-    Valkyrie::Storage::Fedora.new(connection: ActiveFedora.fedora.connection),
+    Valkyrie::Storage::Fedora.new(connection: Ldp::Client.new("http://localhost:8988/rest")),
     :fedora
   )
 

--- a/lib/valkyrie/persistence/fedora/list_node.rb
+++ b/lib/valkyrie/persistence/fedora/list_node.rb
@@ -18,7 +18,7 @@ module Valkyrie::Persistence::Fedora
     end
 
     # Returns the next proxy or a tail sentinel.
-    # @return [ActiveFedora::Orders::ListNode]
+    # @return [RDF::URI]
     def next
       @next ||=
         if next_uri
@@ -31,13 +31,13 @@ module Valkyrie::Persistence::Fedora
     end
 
     # Returns the previous proxy or a head sentinel.
-    # @return [ActiveFedora::Orders::ListNode]
+    # @return [RDF::URI]
     def prev
       @prev ||= node_cache.fetch(prev_uri) if prev_uri
     end
 
     # Graph representation of node.
-    # @return [ActiveFedora::Orders::ListNode::Resource]
+    # @return [Valkyrie::Persistence::Fedora::ListNode::Resource]
     def to_graph
       return RDF::Graph.new if target_id.blank?
       g = Resource.new(rdf_subject)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,9 +21,5 @@ require 'action_dispatch'
 
 SOLR_TEST_URL = "http://127.0.0.1:#{ENV['TEST_JETTY_PORT'] || 8984}/solr/blacklight-core-test"
 
-# Setup to use the fedora.yml in the test app
-ActiveFedora.init(environment: ENV['RACK_ENV'],
-                  fedora_config_path: File.expand_path("../../config/fedora.yml", __FILE__))
-
 ROOT_PATH = Pathname.new(Dir.pwd)
 Dir[Pathname.new("./").join("spec", "support", "**", "*.rb")].sort.each { |file| require_relative file.gsub(/^spec\//, "") }


### PR DESCRIPTION
Fixes #549

ActiveFedora is no longer required for the test suite and should not be
referenced in the documentation.

Note: There is a briefly delay during one of the tests when ActiveFedora
is first called, in order to test the deprecation warning.