### PR TITLE
Removing unused error handling (error is caught somewhere else)

### DIFF
--- a/lib/valkyrie/storage/fedora.rb
+++ b/lib/valkyrie/storage/fedora.rb
@@ -23,8 +23,6 @@ module Valkyrie::Storage
     # @raise Valkyrie::StorageAdapter::FileNotFound if nothing is found
     def find_by(id:)
       Valkyrie::StorageAdapter::StreamFile.new(id: id, io: response(id: id))
-    rescue ::Ldp::Gone
-      raise Valkyrie::StorageAdapter::FileNotFound
     end
 
     # @param file [IO]


### PR DESCRIPTION
Test coverage showed this code wasn't being used — turns out the `response` method was already catching the error.