### PR TITLE
Fix solr persister to pass through exceptions on timeout

### DIFF
--- a/lib/valkyrie/persistence/solr/repository.rb
+++ b/lib/valkyrie/persistence/solr/repository.rb
@@ -38,7 +38,7 @@ module Valkyrie::Persistence::Solr
       connection.add documents, params: COMMIT_PARAMS
     rescue RSolr::Error::Http => exception
       # Error 409 conflict is returned when versions do not match
-      if exception.response[:status] == 409
+      if exception.response&.fetch(:status) == 409
         handle_conflict
       end
       raise exception

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,8 +18,11 @@ require 'active_fedora'
 require "valkyrie"
 require 'pry'
 require 'action_dispatch'
+require 'webmock/rspec'
 
 SOLR_TEST_URL = "http://127.0.0.1:#{ENV['TEST_JETTY_PORT'] || 8984}/solr/blacklight-core-test"
 
 ROOT_PATH = Pathname.new(Dir.pwd)
 Dir[Pathname.new("./").join("spec", "support", "**", "*.rb")].sort.each { |file| require_relative file.gsub(/^spec\//, "") }
+
+WebMock.disable_net_connect!(allow_localhost: true)

--- a/spec/valkyrie/persistence/solr/persister_spec.rb
+++ b/spec/valkyrie/persistence/solr/persister_spec.rb
@@ -76,26 +76,40 @@ RSpec.describe Valkyrie::Persistence::Solr::Persister do
   end
 
   describe "#save" do
+    before do
+      class MyLockingResource < Valkyrie::Resource
+        enable_optimistic_locking
+        attribute :title
+      end
+    end
+
+    after do
+      ActiveSupport::Dependencies.remove_constant("MyLockingResource")
+    end
+
     # supplement specs from shared_specs/locking_persister with a solr-specific test
     # The only error we catch is the 409 conflict
     context "when updating a resource with an invalid token" do
-      before do
-        class MyLockingResource < Valkyrie::Resource
-          enable_optimistic_locking
-          attribute :title
-        end
-      end
-
-      after do
-        ActiveSupport::Dependencies.remove_constant("MyLockingResource")
-      end
-
       it "raises an Rsolr 500 Error" do
         resource = MyLockingResource.new(title: ["My Locked Resource"])
         initial_resource = persister.save(resource: resource)
         invalid_token = Valkyrie::Persistence::OptimisticLockToken.new(adapter_id: adapter.id, token: "NOT_EVEN_A_VALID_TOKEN")
         initial_resource.send("#{Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK}=", [invalid_token])
         expect { persister.save(resource: initial_resource) }.to raise_error(RSolr::Error::Http)
+      end
+    end
+
+    context "when solr does not return a response" do
+      before do
+        WebMock.disable_net_connect!
+        stub_request(:post, "#{SOLR_TEST_URL}/update?softCommit=true&versions=true&wt=json").to_raise(RSolr::Error::Http.new(nil, nil))
+      end
+      after do
+        WebMock.disable_net_connect!(allow_localhost: true)
+      end
+      it "passes the exception through" do
+        resource = MyLockingResource.new(title: ["My Locked Resource"])
+        expect { persister.save(resource: resource) }.to raise_error(RSolr::Error::Http)
       end
     end
   end

--- a/valkyrie.gemspec
+++ b/valkyrie.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry"
+  spec.add_development_dependency "webmock"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "database_cleaner"
   spec.add_development_dependency "simplecov"


### PR DESCRIPTION
This resolves a bug observed via figgy, wherein a timeout from solr sent
back a response with no status and resulted in
`NoMethodError: undefined method `[]' for nil:NilClass`
on `if exception.response[:status] == 409`