### PR TITLE
Adapter consistency

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1,6 +1,7 @@
 Metrics/ClassLength:
   Exclude:
     - 'lib/valkyrie/persistence/fedora/persister.rb'
+    - 'lib/valkyrie/persistence/fedora/query_service.rb'
     - 'lib/valkyrie/persistence/postgres/query_service.rb'
 
 Metrics/MethodLength:

--- a/lib/valkyrie.rb
+++ b/lib/valkyrie.rb
@@ -58,6 +58,11 @@ module Valkyrie
     @logger = logger
   end
 
+  def warn_about_standard_queries!
+    warn "[DEPRECATION] Please enable query normalization to avoid inconsistent results between different adapters by adding `standardize_query_results: true` to your environment block" \
+     " in config\/valkyrie.yml. This will be the behavior in Valkyrie 2.0."
+  end
+
   class Config < OpenStruct
     def metadata_adapter
       Valkyrie::MetadataAdapter.find(super.to_sym)
@@ -68,5 +73,5 @@ module Valkyrie
     end
   end
 
-  module_function :config, :logger, :logger=, :config_root_path, :environment
+  module_function :config, :logger, :logger=, :config_root_path, :environment, :warn_about_standard_queries!
 end

--- a/lib/valkyrie/persistence/fedora/metadata_adapter.rb
+++ b/lib/valkyrie/persistence/fedora/metadata_adapter.rb
@@ -75,6 +75,7 @@ module Valkyrie::Persistence::Fedora
     end
 
     def standardize_query_result?
+      Valkyrie.warn_about_standard_queries! if Valkyrie.config.standardize_query_result != true
       Valkyrie.config.standardize_query_result == true
     end
   end

--- a/lib/valkyrie/persistence/fedora/metadata_adapter.rb
+++ b/lib/valkyrie/persistence/fedora/metadata_adapter.rb
@@ -73,5 +73,9 @@ module Valkyrie::Persistence::Fedora
     def connection_prefix
       "#{connection.http.url_prefix}/#{base_path}"
     end
+
+    def standardize_query_result?
+      Valkyrie.config.standardize_query_result == true
+    end
   end
 end

--- a/lib/valkyrie/persistence/fedora/persister/model_converter.rb
+++ b/lib/valkyrie/persistence/fedora/persister/model_converter.rb
@@ -238,12 +238,20 @@ module Valkyrie::Persistence::Fedora
             obj = calling_mapper.for(property.property).result
             # Append value directly if possible.
             if obj.respond_to?(:value)
-              ordered_list.insert_proxy_for_at(index, obj.value)
+              ordered_list.insert_proxy_for_at(index, proxy_for_value(obj.value))
             # If value is a nested object, take its graph and append it.
             elsif obj.respond_to?(:graph)
               append_to_graph(obj: obj, index: index, property: property.property)
             end
             graph << ordered_list.to_graph
+          end
+        end
+
+        def proxy_for_value(value)
+          if value.is_a?(RDF::Literal) && value.datatype == PermissiveSchema.valkyrie_id
+            ordered_list.adapter.id_to_uri(value)
+          else
+            value
           end
         end
 

--- a/lib/valkyrie/persistence/fedora/query_service.rb
+++ b/lib/valkyrie/persistence/fedora/query_service.rb
@@ -29,6 +29,7 @@ module Valkyrie::Persistence::Fedora
 
     # (see Valkyrie::Persistence::Memory::QueryService#find_many_by_ids)
     def find_many_by_ids(ids:)
+      ids = ids.uniq if adapter.standardize_query_result?
       ids.map do |id|
         begin
           find_by(id: id)
@@ -42,6 +43,7 @@ module Valkyrie::Persistence::Fedora
     def find_parents(resource:)
       content = content_with_inbound(id: resource.id)
       parent_ids = content.graph.query([nil, RDF::Vocab::ORE.proxyFor, nil]).map(&:subject).map { |x| x.to_s.gsub(/#.*/, '') }.map { |x| adapter.uri_to_id(x) }
+      parent_ids.uniq! if adapter.standardize_query_result?
       parent_ids.lazy.map do |id|
         find_by(id: id)
       end
@@ -114,6 +116,7 @@ module Valkyrie::Persistence::Fedora
       content = content_with_inbound(id: resource.id)
       property_uri =  adapter.schema.predicate_for(property: property, resource: nil)
       ids = content.graph.query([nil, property_uri, nil]).map(&:subject).map { |x| x.to_s.gsub(/#.*/, '') }.map { |x| adapter.uri_to_id(x) }
+      ids.uniq! if adapter.standardize_query_result?
       ids.lazy.map do |id|
         find_by(id: id)
       end

--- a/lib/valkyrie/persistence/fedora/query_service.rb
+++ b/lib/valkyrie/persistence/fedora/query_service.rb
@@ -113,12 +113,10 @@ module Valkyrie::Persistence::Fedora
     # *Also, an initial request is made to find the URIs of the resources referencing the resource in the query*
     def find_inverse_references_by(resource:, property:)
       ensure_persisted(resource)
-      content = content_with_inbound(id: resource.id)
-      property_uri =  adapter.schema.predicate_for(property: property, resource: nil)
-      ids = content.graph.query([nil, property_uri, nil]).map(&:subject).map { |x| x.to_s.gsub(/#.*/, '') }.map { |x| adapter.uri_to_id(x) }
-      ids.uniq! if adapter.standardize_query_result?
-      ids.lazy.map do |id|
-        find_by(id: id)
+      if ordered_property?(resource: resource, property: property)
+        find_inverse_references_by_ordered(resource: resource, property: property)
+      else
+        find_inverse_references_by_unordered(resource: resource, property: property)
       end
     end
 
@@ -128,6 +126,21 @@ module Valkyrie::Persistence::Fedora
     end
 
     private
+
+      def find_inverse_references_by_unordered(resource:, property:)
+        content = content_with_inbound(id: resource.id)
+        property_uri = adapter.schema.predicate_for(property: property, resource: nil)
+        ids = content.graph.query([nil, property_uri, adapter.id_to_uri(resource.id)]).map(&:subject).map { |x| x.to_s.gsub(/#.*/, '') }.map { |x| adapter.uri_to_id(x) }
+        ids.uniq! if adapter.standardize_query_result?
+        ids.lazy.map { |id| find_by(id: id) }
+      end
+
+      def find_inverse_references_by_ordered(resource:, property:)
+        content = content_with_inbound(id: resource.id)
+        ids = content.graph.query([nil, ::RDF::Vocab::ORE.proxyFor, adapter.id_to_uri(resource.id)]).map(&:subject).map { |x| x.to_s.gsub(/#.*/, '') }.map { |x| adapter.uri_to_id(x) }
+        ids.uniq! if adapter.standardize_query_result?
+        ids.lazy.map { |id| find_by(id: id) }.select { |o| o[property].include?(resource.id) }
+      end
 
       # Ensures that an object is (or can be cast into a) Valkyrie::ID
       # @return [Valkyrie::ID]
@@ -153,6 +166,10 @@ module Valkyrie::Persistence::Fedora
       # @raise [ArgumentError]
       def ensure_persisted(resource)
         raise ArgumentError, 'resource is not saved' unless resource.persisted?
+      end
+
+      def ordered_property?(resource:, property:)
+        resource.class.schema[property].meta.try(:[], :ordered)
       end
   end
 end

--- a/lib/valkyrie/persistence/memory/metadata_adapter.rb
+++ b/lib/valkyrie/persistence/memory/metadata_adapter.rb
@@ -29,5 +29,9 @@ module Valkyrie::Persistence::Memory
     def id
       @id ||= Valkyrie::ID.new(Digest::MD5.hexdigest(self.class.to_s))
     end
+
+    def standardize_query_result?
+      Valkyrie.config.standardize_query_result == true
+    end
   end
 end

--- a/lib/valkyrie/persistence/memory/metadata_adapter.rb
+++ b/lib/valkyrie/persistence/memory/metadata_adapter.rb
@@ -31,6 +31,7 @@ module Valkyrie::Persistence::Memory
     end
 
     def standardize_query_result?
+      Valkyrie.warn_about_standard_queries! if Valkyrie.config.standardize_query_result != true
       Valkyrie.config.standardize_query_result == true
     end
   end

--- a/lib/valkyrie/persistence/postgres/metadata_adapter.rb
+++ b/lib/valkyrie/persistence/postgres/metadata_adapter.rb
@@ -37,6 +37,7 @@ module Valkyrie::Persistence::Postgres
     end
 
     def standardize_query_result?
+      Valkyrie.warn_about_standard_queries! if Valkyrie.config.standardize_query_result != true
       Valkyrie.config.standardize_query_result == true
     end
   end

--- a/lib/valkyrie/persistence/postgres/metadata_adapter.rb
+++ b/lib/valkyrie/persistence/postgres/metadata_adapter.rb
@@ -17,7 +17,8 @@ module Valkyrie::Persistence::Postgres
     # @return [Class] {Valkyrie::Persistence::Postgres::QueryService}
     def query_service
       @query_service ||= Valkyrie::Persistence::Postgres::QueryService.new(
-        resource_factory: resource_factory
+        resource_factory: resource_factory,
+        adapter: self
       )
     end
 
@@ -33,6 +34,10 @@ module Valkyrie::Persistence::Postgres
         to_hash = "#{resource_factory.orm_class.connection_config['host']}:#{resource_factory.orm_class.connection_config['database']}"
         Valkyrie::ID.new(Digest::MD5.hexdigest(to_hash))
       end
+    end
+
+    def standardize_query_result?
+      Valkyrie.config.standardize_query_result == true
     end
   end
 end

--- a/lib/valkyrie/persistence/solr/metadata_adapter.rb
+++ b/lib/valkyrie/persistence/solr/metadata_adapter.rb
@@ -46,7 +46,8 @@ module Valkyrie::Persistence::Solr
     def query_service
       @query_service ||= Valkyrie::Persistence::Solr::QueryService.new(
         connection: connection,
-        resource_factory: resource_factory
+        resource_factory: resource_factory,
+        adapter: self
       )
     end
 
@@ -61,6 +62,10 @@ module Valkyrie::Persistence::Solr
     #   to convert a resource to a solr document and back.
     def resource_factory
       Valkyrie::Persistence::Solr::ResourceFactory.new(resource_indexer: resource_indexer, adapter: self)
+    end
+
+    def standardize_query_result?
+      Valkyrie.config.standardize_query_result == true
     end
 
     # Class modeling the indexer for cases where indexing is *not* performed

--- a/lib/valkyrie/persistence/solr/metadata_adapter.rb
+++ b/lib/valkyrie/persistence/solr/metadata_adapter.rb
@@ -65,6 +65,7 @@ module Valkyrie::Persistence::Solr
     end
 
     def standardize_query_result?
+      Valkyrie.warn_about_standard_queries! if Valkyrie.config.standardize_query_result != true
       Valkyrie.config.standardize_query_result == true
     end
 

--- a/lib/valkyrie/persistence/solr/queries/find_ordered_references_query.rb
+++ b/lib/valkyrie/persistence/solr/queries/find_ordered_references_query.rb
@@ -17,13 +17,13 @@ module Valkyrie::Persistence::Solr::Queries
 
     def each
       # map them off of the property to fix solr's deduplication
-      property_values.map { |id| unordered_members.find { |member| member.id == id } } .each do |value|
+      property_values.map { |id| unordered_members.find { |member| member.id == id } } .reject(&:nil?).each do |value|
         yield value
       end
     end
 
     def unordered_members
-      docs.map do |doc|
+      @unordered_members ||= docs.map do |doc|
         resource_factory.to_resource(object: doc)
       end
     end

--- a/lib/valkyrie/persistence/solr/query_service.rb
+++ b/lib/valkyrie/persistence/solr/query_service.rb
@@ -3,12 +3,13 @@ module Valkyrie::Persistence::Solr
   require 'valkyrie/persistence/solr/queries'
   # Query Service for Solr MetadataAdapter.
   class QueryService
-    attr_reader :connection, :resource_factory
+    attr_reader :connection, :resource_factory, :adapter
     # @param [RSolr::Client] connection
     # @param [Valkyrie::Persistence::Solr::ResourceFactory] resource_factory
-    def initialize(connection:, resource_factory:)
+    def initialize(connection:, resource_factory:, adapter:)
       @connection = connection
       @resource_factory = resource_factory
+      @adapter = adapter
     end
 
     # Find resources by Valkyrie ID
@@ -65,7 +66,13 @@ module Valkyrie::Persistence::Solr
     # @param [Valkyrie::Resource] parent resource
     # @return [Array<Valkyrie::Resource>] member resources
     def find_members(resource:, model: nil)
-      Valkyrie::Persistence::Solr::Queries::FindMembersQuery.new(resource: resource, model: model, connection: connection, resource_factory: resource_factory).run
+      Valkyrie::Persistence::Solr::Queries::FindMembersQuery.new(
+        resource: resource,
+        model: model,
+        connection: connection,
+        resource_factory: resource_factory,
+        standardize_query_result: adapter.standardize_query_result?
+      ).run
     end
 
     # Find all of the resources referenced by a given Valkyrie Resource using a specific property

--- a/spec/valkyrie/persistence/fedora/metadata_adapter_spec.rb
+++ b/spec/valkyrie/persistence/fedora/metadata_adapter_spec.rb
@@ -46,4 +46,13 @@ RSpec.describe Valkyrie::Persistence::Fedora::MetadataAdapter do
       expect(adapter.id.to_s).to eq expected
     end
   end
+
+  # rubocop:disable Metrics/LineLength
+  describe "#standardize_query_result?" do
+    it "throws a deprecation warning when it's set to false" do
+      allow(Valkyrie.config).to receive(:standardize_query_result).and_return(false)
+      expect { adapter.standardize_query_result? }.to output(/Please enable query normalization to avoid inconsistent results between different adapters by adding `standardize_query_results: true` to your environment block in config\/valkyrie.yml. This will be the behavior in Valkyrie 2.0./).to_stderr
+    end
+  end
+  # rubocop:enable Metrics/LineLength
 end

--- a/spec/valkyrie/persistence/memory/metadata_adapter_spec.rb
+++ b/spec/valkyrie/persistence/memory/metadata_adapter_spec.rb
@@ -12,4 +12,13 @@ RSpec.describe Valkyrie::Persistence::Memory::MetadataAdapter do
       expect(adapter.id.to_s).to eq expected
     end
   end
+
+  # rubocop:disable Metrics/LineLength
+  describe "#standardize_query_result?" do
+    it "throws a deprecation warning when it's set to false" do
+      allow(Valkyrie.config).to receive(:standardize_query_result).and_return(false)
+      expect { adapter.standardize_query_result? }.to output(/Please enable query normalization to avoid inconsistent results between different adapters by adding `standardize_query_results: true` to your environment block in config\/valkyrie.yml. This will be the behavior in Valkyrie 2.0./).to_stderr
+    end
+  end
+  # rubocop:enable Metrics/LineLength
 end

--- a/spec/valkyrie/persistence/postgres/metadata_adapter_spec.rb
+++ b/spec/valkyrie/persistence/postgres/metadata_adapter_spec.rb
@@ -13,4 +13,13 @@ RSpec.describe Valkyrie::Persistence::Postgres::MetadataAdapter do
       expect(adapter.id.to_s).to eq expected
     end
   end
+
+  # rubocop:disable Metrics/LineLength
+  describe "#standardize_query_result?" do
+    it "throws a deprecation warning when it's set to false" do
+      allow(Valkyrie.config).to receive(:standardize_query_result).and_return(false)
+      expect { adapter.standardize_query_result? }.to output(/Please enable query normalization to avoid inconsistent results between different adapters by adding `standardize_query_results: true` to your environment block in config\/valkyrie.yml. This will be the behavior in Valkyrie 2.0./).to_stderr
+    end
+  end
+  # rubocop:enable Metrics/LineLength
 end

--- a/spec/valkyrie/persistence/solr/metadata_adapter_spec.rb
+++ b/spec/valkyrie/persistence/solr/metadata_adapter_spec.rb
@@ -13,4 +13,13 @@ RSpec.describe Valkyrie::Persistence::Solr::MetadataAdapter do
       expect(adapter.id.to_s).to eq expected
     end
   end
+
+  # rubocop:disable Metrics/LineLength
+  describe "#standardize_query_result?" do
+    it "throws a deprecation warning when it's set to false" do
+      allow(Valkyrie.config).to receive(:standardize_query_result).and_return(false)
+      expect { adapter.standardize_query_result? }.to output(/Please enable query normalization to avoid inconsistent results between different adapters by adding `standardize_query_results: true` to your environment block in config\/valkyrie.yml. This will be the behavior in Valkyrie 2.0./).to_stderr
+    end
+  end
+  # rubocop:enable Metrics/LineLength
 end


### PR DESCRIPTION
This is based on the work started by @escowles. I reorganised the specs so that they are among all the method descriptions rather than in one block at the end.

I've also fixed the adapters to pass the tests except for Fedora which fails the find_inverse_references_by tests when the property is ordered. This is the case where it just didn't work at all to begin with. It's because there's the whole proxy list structure and the current implementation doesn't account for that.

I tried this which I thought should work but won't because the proxies seem to store the proxy_for as a literal rather than a reference to the object. So content_with_inbound doesn't return even the proxy objects.

```ruby
    def find_inverse_references_by(resource:, property:)
      ensure_persisted(resource)
      content = content_with_inbound(id: resource.id)
      property_uri = adapter.schema.predicate_for(property: property, resource: nil)
      resource_uri = adapter.id_to_uri(resource.id)
      if ordered_property?(resource: resource, property: property)
        ids = content.graph.query([nil, ::RDF::Vocab::ORE.proxyFor, resource_uri]).map(&:subject).map { |x| x.to_s.gsub(/#.*/, '') }.map { |x| adapter.uri_to_id(x) }
        ids.uniq.lazy.map do |id|
          o = find_by(id: id)
          o[property].include?(resource.id) ? o : nil
        end .reject(&:nil?)
      else
        ids = content.graph.query([nil, property_uri, resource_uri]).map(&:subject).map { |x| x.to_s.gsub(/#.*/, '') }.map { |x| adapter.uri_to_id(x) }
        ids.uniq.lazy.map do |id|
          find_by(id: id)
        end
      end
    end
```