### PR TITLE
Add disk_path to shared specs.

### DIFF
--- a/lib/valkyrie/specs/shared_specs/file.rb
+++ b/lib/valkyrie/specs/shared_specs/file.rb
@@ -9,4 +9,9 @@ RSpec.shared_examples 'a Valkyrie::StorageAdapter::File' do
   it { is_expected.to respond_to(:read) }
   it { is_expected.to respond_to(:rewind) }
   it { is_expected.to respond_to(:id) }
+  describe "#disk_path" do
+    it "returns an existing disk path" do
+      expect(File.exist?(file.disk_path)).to eq true
+    end
+  end
 end

--- a/spec/valkyrie/storage_adapter/file_spec.rb
+++ b/spec/valkyrie/storage_adapter/file_spec.rb
@@ -3,21 +3,16 @@ require 'spec_helper'
 require 'valkyrie/specs/shared_specs'
 
 RSpec.describe Valkyrie::StorageAdapter::File do
-  let(:io) { instance_double(::File) }
+  let(:io) do
+    File.open(ROOT_PATH.join("spec", "fixtures", "files", "example.tif"))
+  end
   let(:file) { described_class.new(id: "test_file", io: io) }
   it_behaves_like "a Valkyrie::StorageAdapter::File"
 
   describe '#disk_path' do
-    before do
-      allow(io).to receive(:read).and_return('Lorem ipsum dolor sit amet, consectetur adipiscing elit.')
-    end
     context 'with the disk or memory storage adapter' do
-      before do
-        allow(io).to receive(:path).and_return('/test/path')
-      end
-
       it 'provides a path to the file for the storage adapter' do
-        expect(file.disk_path).to eq Pathname.new('/test/path')
+        expect(file.disk_path).to eq Pathname.new(io.path)
       end
     end
   end

--- a/spec/valkyrie/storage_adapter/stream_file_spec.rb
+++ b/spec/valkyrie/storage_adapter/stream_file_spec.rb
@@ -3,13 +3,10 @@ require 'spec_helper'
 require 'valkyrie/specs/shared_specs'
 
 RSpec.describe Valkyrie::StorageAdapter::StreamFile do
-  let(:io) { instance_double(StringIO) }
+  let(:io) { StringIO.new("Loreim ipsum dolor sit amet, consectur apidiscing elit.") }
   let(:file) { described_class.new(id: "test_file", io: io) }
   it_behaves_like "a Valkyrie::StorageAdapter::File"
   describe '#disk_path' do
-    before do
-      allow(io).to receive(:read).and_return('Lorem ipsum dolor sit amet, consectetur adipiscing elit.')
-    end
     context 'with the disk or memory storage adapter' do
       it 'provides a path to the file for the storage adapter' do
         expect(file.disk_path).to be_a Pathname


### PR DESCRIPTION
Officially adds `disk_path` to the public API.

Closes #610.