### PR TITLE
Fedora 5 support

### DIFF
--- a/.docker-stack/valkyrie-development/docker-compose.yml
+++ b/.docker-stack/valkyrie-development/docker-compose.yml
@@ -1,17 +1,24 @@
 ---
 version: '3.4'
 volumes:
-  fedora:
+  fedora4:
+  fedora5:
   db:
   solr_repo:
   solr_index:
 services:
-  fedora:
-    image: nulib/fcrepo4
+  fedora4:
+    image: nulib/fcrepo4:4.7.5
     volumes:
-    - fedora:/data
+    - fedora4:/data
     ports:
     - 8986:8080
+  fedora5:
+    image: nulib/fcrepo4:5.0.0-RC-2
+    volumes:
+    - fedora5:/data
+    ports:
+    - 8996:8080
   db:
     image: healthcheck/postgres:alpine
     volumes:

--- a/.docker-stack/valkyrie-test/docker-compose.yml
+++ b/.docker-stack/valkyrie-test/docker-compose.yml
@@ -1,17 +1,24 @@
 ---
 version: '3.4'
 volumes:
-  fedora:
+  fedora4:
+  fedora5:
   db:
   solr_repo:
   solr_index:
 services:
-  fedora:
-    image: nulib/fcrepo4
+  fedora4:
+    image: nulib/fcrepo4:4.7.5
     volumes:
-    - fedora:/data
+    - fedora4:/data
     ports:
     - 8988:8080
+  fedora5:
+    image: nulib/fcrepo4:5.0.0-RC-2
+    volumes:
+    - fedora5:/data
+    ports:
+    - 8998:8080
   db:
     image: healthcheck/postgres:alpine
     volumes:

--- a/README.md
+++ b/README.md
@@ -241,6 +241,22 @@ By default, it is assumed that a Valkyrie repository implementation shall use a 
 1. Run `rake docker:test:down` to stop the server stack
    * The test stack cleans up after itself on exit.
 
+## Fedora 5 Compatibility
+When running tests:
+* Specify a Fedora 5 release when running test servers:
+   ```
+   FCREPO_VERSION=5.0.0-RC-1 rake server:test
+   ```
+* Enable Fedora 5 compatibility when running tests:
+   ```
+   FEDORA5_COMPAT=true rspec
+   ```
+When configuring your adapter:
+* Include the `fedora_version` paramter in your metadata or storage adapter config, e.g.:
+   ```
+   Valkyrie::Storage::Fedora.new(connection: Ldp::Client.new("http://localhost:8988/rest"), fedora_version: 5)
+   ```
+
 The development and test stacks use fully contained virtual volumes and bind all services to different ports, so they can be running at the same time without issue.
 
 ## Get Help

--- a/README.md
+++ b/README.md
@@ -242,19 +242,9 @@ By default, it is assumed that a Valkyrie repository implementation shall use a 
    * The test stack cleans up after itself on exit.
 
 ## Fedora 5 Compatibility
-When running tests:
-* Specify a Fedora 5 release when running test servers:
+When configuring your adapter, include the `fedora_version` parameter in your metadata or storage adapter config.  If Fedora requires auth, you can also include that in the URL, e.g.:
    ```
-   FCREPO_VERSION=5.0.0-RC-1 rake server:test
-   ```
-* Enable Fedora 5 compatibility when running tests:
-   ```
-   FEDORA5_COMPAT=true rspec
-   ```
-When configuring your adapter:
-* Include the `fedora_version` paramter in your metadata or storage adapter config, e.g.:
-   ```
-   Valkyrie::Storage::Fedora.new(connection: Ldp::Client.new("http://localhost:8988/rest"), fedora_version: 5)
+   Valkyrie::Storage::Fedora.new(connection: Ldp::Client.new("http://fedoraAdmin:fedoraAdmin@localhost:8988/rest"), fedora_version: 5)
    ```
 
 The development and test stacks use fully contained virtual volumes and bind all services to different ports, so they can be running at the same time without issue.

--- a/lib/valkyrie/persistence/fedora/metadata_adapter.rb
+++ b/lib/valkyrie/persistence/fedora/metadata_adapter.rb
@@ -20,6 +20,8 @@ module Valkyrie::Persistence::Fedora
       @base_path = base_path
       @schema = schema
       @fedora_version = fedora_version
+
+      warn "[DEPRECATION] `fedora_version` will default to 5 in the next major release." unless fedora_version
     end
 
     # Construct the query service object using this adapter

--- a/lib/valkyrie/persistence/fedora/metadata_adapter.rb
+++ b/lib/valkyrie/persistence/fedora/metadata_adapter.rb
@@ -9,15 +9,17 @@ module Valkyrie::Persistence::Fedora
   #     schema: Valkyrie::Persistence::Fedora::PermissiveSchema.new(title: RDF::URI("http://bad.com/title"))
   #   )
   class MetadataAdapter
-    attr_reader :connection, :base_path, :schema
+    attr_reader :connection, :base_path, :schema, :fedora_version
 
     # @param [Ldp::Client] connection
     # @param [String] base_path
     # @param [Valkyrie::Persistence::Fedora::PermissiveSchema] schema
-    def initialize(connection:, base_path: "/", schema: Valkyrie::Persistence::Fedora::PermissiveSchema.new)
+    # @param [Integer] fedora_version
+    def initialize(connection:, base_path: "/", schema: Valkyrie::Persistence::Fedora::PermissiveSchema.new, fedora_version:)
       @connection = connection
       @base_path = base_path
       @schema = schema
+      @fedora_version = fedora_version
     end
 
     # Construct the query service object using this adapter
@@ -56,7 +58,8 @@ module Valkyrie::Persistence::Fedora
     # @param [RDF::URI] id the Valkyrie ID
     # @return [RDF::URI]
     def id_to_uri(id)
-      RDF::URI("#{connection_prefix}/#{pair_path(id)}/#{CGI.escape(id.to_s)}")
+      prefix = fedora_version == 5 ? "" : "#{pair_path(id)}/"
+      RDF::URI("#{connection_prefix}/#{prefix}#{CGI.escape(id.to_s)}")
     end
 
     # Generate the pairtree path for a given Valkyrie ID

--- a/lib/valkyrie/persistence/fedora/query_service.rb
+++ b/lib/valkyrie/persistence/fedora/query_service.rb
@@ -54,7 +54,7 @@ module Valkyrie::Persistence::Fedora
     # @return [Array<RDF::URI>]
     def include_uris
       [
-        ::RDF::Vocab::Fcrepo4.InboundReferences
+        adapter.fedora_version == 5 ? "http://fedora.info/definitions/fcrepo#PreferInboundReferences" : ::RDF::Vocab::Fcrepo4.InboundReferences
       ]
     end
 

--- a/lib/valkyrie/storage/fedora.rb
+++ b/lib/valkyrie/storage/fedora.rb
@@ -10,6 +10,8 @@ module Valkyrie::Storage
       @connection = connection
       @base_path = base_path
       @fedora_version = fedora_version
+
+      warn "[DEPRECATION] `fedora_version` will default to 5 in the next major release." unless fedora_version
     end
 
     # @param id [Valkyrie::ID]

--- a/lib/valkyrie/storage/fedora.rb
+++ b/lib/valkyrie/storage/fedora.rb
@@ -2,13 +2,14 @@
 module Valkyrie::Storage
   # Implements the DataMapper Pattern to store binary data in fedora
   class Fedora
-    attr_reader :connection, :base_path
+    attr_reader :connection, :base_path, :fedora_version
     PROTOCOL = 'fedora://'
 
     # @param [Ldp::Client] connection
-    def initialize(connection:, base_path: "/")
+    def initialize(connection:, base_path: "/", fedora_version:)
       @connection = connection
       @base_path = base_path
+      @fedora_version = fedora_version
     end
 
     # @param id [Valkyrie::ID]
@@ -31,11 +32,13 @@ module Valkyrie::Storage
     # @return [Valkyrie::StorageAdapter::StreamFile]
     def upload(file:, original_filename:, resource:)
       identifier = id_to_uri(resource.id) + '/original'
+      sha1 = fedora_version == 5 ? "sha" : "sha1"
       connection.http.put do |request|
         request.url identifier
         request.headers['Content-Type'] = file.content_type
         request.headers['Content-Disposition'] = "attachment; filename=\"#{original_filename}\""
-        request.headers['digest'] = "sha1=#{Digest::SHA1.file(file)}"
+        request.headers['digest'] = "#{sha1}=#{Digest::SHA1.file(file)}"
+        request.headers['link'] = "<http://www.w3.org/ns/ldp#NonRDFSource>; rel=\"type\""
         request.body = file.tempfile.read
       end
       find_by(id: Valkyrie::ID.new(identifier.to_s.sub(/^.+\/\//, PROTOCOL)))

--- a/spec/support/fedora_helper.rb
+++ b/spec/support/fedora_helper.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+module FedoraHelper
+  def fedora_adapter_config(base_path:, schema: nil)
+    opts = {
+      base_path: base_path,
+      connection: ::Ldp::Client.new("http://localhost:8988/rest"),
+      fedora_version: ENV["FEDORA5_COMPAT"].present? ? 5 : 4
+    }
+    opts[:schema] = schema if schema
+    opts
+  end
+
+  def wipe_fedora!(base_path:)
+    Valkyrie::Persistence::Fedora::MetadataAdapter.new(fedora_adapter_config(base_path: base_path)).persister.wipe!
+  end
+end
+
+RSpec.configure do |config|
+  config.before do
+    wipe_fedora!(base_path: "test_fed")
+  end
+  config.include FedoraHelper
+end

--- a/spec/support/fedora_helper.rb
+++ b/spec/support/fedora_helper.rb
@@ -1,23 +1,25 @@
 # frozen_string_literal: true
 module FedoraHelper
-  def fedora_adapter_config(base_path:, schema: nil)
+  def fedora_adapter_config(base_path:, schema: nil, fedora_version: 4)
+    port = fedora_version == 4 ? 8988 : 8998
     opts = {
       base_path: base_path,
-      connection: ::Ldp::Client.new("http://localhost:8988/rest"),
-      fedora_version: ENV["FEDORA5_COMPAT"].present? ? 5 : 4
+      connection: ::Ldp::Client.new("http://localhost:#{port}/rest"),
+      fedora_version: fedora_version
     }
     opts[:schema] = schema if schema
     opts
   end
 
-  def wipe_fedora!(base_path:)
-    Valkyrie::Persistence::Fedora::MetadataAdapter.new(fedora_adapter_config(base_path: base_path)).persister.wipe!
+  def wipe_fedora!(base_path:, fedora_version: 4)
+    Valkyrie::Persistence::Fedora::MetadataAdapter.new(fedora_adapter_config(base_path: base_path, fedora_version: fedora_version)).persister.wipe!
   end
 end
 
 RSpec.configure do |config|
   config.before do
-    wipe_fedora!(base_path: "test_fed")
+    wipe_fedora!(base_path: "test_fed", fedora_version: 4)
+    wipe_fedora!(base_path: "test_fed", fedora_version: 5)
   end
   config.include FedoraHelper
 end

--- a/spec/support/fedora_helper.rb
+++ b/spec/support/fedora_helper.rb
@@ -4,11 +4,15 @@ module FedoraHelper
     port = fedora_version == 4 ? 8988 : 8998
     opts = {
       base_path: base_path,
-      connection: ::Ldp::Client.new("http://localhost:#{port}/rest"),
+      connection: ::Ldp::Client.new("http://#{fedora_auth}localhost:#{port}/rest"),
       fedora_version: fedora_version
     }
     opts[:schema] = schema if schema
     opts
+  end
+
+  def fedora_auth
+    "fedoraAdmin:fedoraAdmin@"
   end
 
   def wipe_fedora!(base_path:, fedora_version: 4)

--- a/spec/support/wipe_raw_fedora_adapter.rb
+++ b/spec/support/wipe_raw_fedora_adapter.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-RSpec.configure do |config|
-  config.before do
-    Valkyrie::Persistence::Fedora::MetadataAdapter.new(connection: ::Ldp::Client.new("http://localhost:8988/rest"), base_path: "test_fed").persister.wipe!
-  end
-end

--- a/spec/valkyrie/persistence/fedora/metadata_adapter_spec.rb
+++ b/spec/valkyrie/persistence/fedora/metadata_adapter_spec.rb
@@ -3,60 +3,66 @@ require 'spec_helper'
 require 'valkyrie/specs/shared_specs'
 
 RSpec.describe Valkyrie::Persistence::Fedora::MetadataAdapter do
-  let(:adapter) { described_class.new(fedora_adapter_config(base_path: "test_fed")) }
-  it_behaves_like "a Valkyrie::MetadataAdapter"
+  [4, 5].each do |fedora_version|
+    context "fedora #{fedora_version}" do
+      let(:version) { fedora_version }
+      let(:adapter) { described_class.new(fedora_adapter_config(base_path: "test_fed", fedora_version: version)) }
+      it_behaves_like "a Valkyrie::MetadataAdapter"
 
-  describe "#schema" do
-    context "by default" do
-      specify { expect(adapter.schema).to be_a Valkyrie::Persistence::Fedora::PermissiveSchema }
-    end
+      describe "#schema" do
+        context "by default" do
+          specify { expect(adapter.schema).to be_a Valkyrie::Persistence::Fedora::PermissiveSchema }
+        end
 
-    context "with a custom schema" do
-      let(:adapter) { described_class.new(fedora_adapter_config(base_path: "test_fed", schema: "custom-schema")) }
-      specify { expect(adapter.schema).to eq("custom-schema") }
-    end
-  end
-
-  describe "#id_to_uri" do
-    it "converts ids with a slash" do
-      id = "test/default"
-      if adapter.fedora_version == 5
-        expect(adapter.id_to_uri(id).to_s).to eq "http://localhost:8988/rest/test_fed/test%2Fdefault"
-      else
-        expect(adapter.id_to_uri(id).to_s).to eq "http://localhost:8988/rest/test_fed/te/st/test%2Fdefault"
+        context "with a custom schema" do
+          let(:adapter) { described_class.new(fedora_adapter_config(base_path: "test_fed", schema: "custom-schema", fedora_version: version)) }
+          specify { expect(adapter.schema).to eq("custom-schema") }
+        end
       end
-    end
-  end
 
-  describe "#uri_to_id" do
-    it "converts ids with a slash" do
-      uri = adapter.id_to_uri("test/default")
-      expect(adapter.uri_to_id(uri).to_s).to eq "test/default"
-    end
-  end
+      describe "#id_to_uri" do
+        it "converts ids with a slash" do
+          id = "test/default"
+          if adapter.fedora_version == 4
 
-  describe "#pair_path" do
-    it "creates pairs until the first dash" do
-      expect(adapter.pair_path('abcdef-ghijkl')).to eq('ab/cd/ef')
-    end
-    it "creates pairs until the first slash" do
-      expect(adapter.pair_path('admin_set/default')).to eq('ad/mi/n_/se/t')
-    end
-  end
+            expect(adapter.id_to_uri(id).to_s).to eq "http://localhost:8988/rest/test_fed/te/st/test%2Fdefault"
+          else
+            expect(adapter.id_to_uri(id).to_s).to eq "http://localhost:8998/rest/test_fed/test%2Fdefault"
+          end
+        end
+      end
 
-  describe "#id" do
-    it "creates an md5 hash from the connection_prefix" do
-      expected = Digest::MD5.hexdigest adapter.connection_prefix
-      expect(adapter.id.to_s).to eq expected
-    end
-  end
+      describe "#uri_to_id" do
+        it "converts ids with a slash" do
+          uri = adapter.id_to_uri("test/default")
+          expect(adapter.uri_to_id(uri).to_s).to eq "test/default"
+        end
+      end
 
-  # rubocop:disable Metrics/LineLength
-  describe "#standardize_query_result?" do
-    it "throws a deprecation warning when it's set to false" do
-      allow(Valkyrie.config).to receive(:standardize_query_result).and_return(false)
-      expect { adapter.standardize_query_result? }.to output(/Please enable query normalization to avoid inconsistent results between different adapters by adding `standardize_query_results: true` to your environment block in config\/valkyrie.yml. This will be the behavior in Valkyrie 2.0./).to_stderr
+      describe "#pair_path" do
+        it "creates pairs until the first dash" do
+          expect(adapter.pair_path('abcdef-ghijkl')).to eq('ab/cd/ef')
+        end
+        it "creates pairs until the first slash" do
+          expect(adapter.pair_path('admin_set/default')).to eq('ad/mi/n_/se/t')
+        end
+      end
+
+      describe "#id" do
+        it "creates an md5 hash from the connection_prefix" do
+          expected = Digest::MD5.hexdigest adapter.connection_prefix
+          expect(adapter.id.to_s).to eq expected
+        end
+      end
+
+      # rubocop:disable Metrics/LineLength
+      describe "#standardize_query_result?" do
+        it "throws a deprecation warning when it's set to false" do
+          allow(Valkyrie.config).to receive(:standardize_query_result).and_return(false)
+          expect { adapter.standardize_query_result? }.to output(/Please enable query normalization to avoid inconsistent results between different adapters by adding `standardize_query_results: true` to your environment block in config\/valkyrie.yml. This will be the behavior in Valkyrie 2.0./).to_stderr
+        end
+      end
+      # rubocop:enable Metrics/LineLength
     end
   end
-  # rubocop:enable Metrics/LineLength
 end

--- a/spec/valkyrie/persistence/fedora/metadata_adapter_spec.rb
+++ b/spec/valkyrie/persistence/fedora/metadata_adapter_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 require 'valkyrie/specs/shared_specs'
 
 RSpec.describe Valkyrie::Persistence::Fedora::MetadataAdapter do
-  let(:adapter) { described_class.new(connection: ::Ldp::Client.new("http://localhost:8988/rest"), base_path: "test_fed") }
+  let(:adapter) { described_class.new(fedora_adapter_config(base_path: "test_fed")) }
   it_behaves_like "a Valkyrie::MetadataAdapter"
 
   describe "#schema" do
@@ -12,7 +12,7 @@ RSpec.describe Valkyrie::Persistence::Fedora::MetadataAdapter do
     end
 
     context "with a custom schema" do
-      let(:adapter) { described_class.new(connection: ::Ldp::Client.new("http://localhost:8988/rest"), base_path: "test_fed", schema: "custom-schema") }
+      let(:adapter) { described_class.new(fedora_adapter_config(base_path: "test_fed", schema: "custom-schema")) }
       specify { expect(adapter.schema).to eq("custom-schema") }
     end
   end
@@ -20,7 +20,11 @@ RSpec.describe Valkyrie::Persistence::Fedora::MetadataAdapter do
   describe "#id_to_uri" do
     it "converts ids with a slash" do
       id = "test/default"
-      expect(adapter.id_to_uri(id).to_s).to eq "http://localhost:8988/rest/test_fed/te/st/test%2Fdefault"
+      if adapter.fedora_version == 5
+        expect(adapter.id_to_uri(id).to_s).to eq "http://localhost:8988/rest/test_fed/test%2Fdefault"
+      else
+        expect(adapter.id_to_uri(id).to_s).to eq "http://localhost:8988/rest/test_fed/te/st/test%2Fdefault"
+      end
     end
   end
 

--- a/spec/valkyrie/persistence/fedora/persister/model_converter_spec.rb
+++ b/spec/valkyrie/persistence/fedora/persister/model_converter_spec.rb
@@ -4,9 +4,7 @@ require 'spec_helper'
 RSpec.describe Valkyrie::Persistence::Fedora::Persister::ModelConverter do
   let(:adapter) do
     Valkyrie::Persistence::Fedora::MetadataAdapter.new(
-      connection: ::Ldp::Client.new("http://localhost:8988/rest"),
-      base_path: "test_fed",
-      schema: schema
+      fedora_adapter_config(base_path: "test_fed", schema: schema)
     )
   end
 

--- a/spec/valkyrie/persistence/fedora/persister/model_converter_spec.rb
+++ b/spec/valkyrie/persistence/fedora/persister/model_converter_spec.rb
@@ -2,41 +2,46 @@
 require 'spec_helper'
 
 RSpec.describe Valkyrie::Persistence::Fedora::Persister::ModelConverter do
-  let(:adapter) do
-    Valkyrie::Persistence::Fedora::MetadataAdapter.new(
-      fedora_adapter_config(base_path: "test_fed", schema: schema)
-    )
-  end
+  [4, 5].each do |fedora_version|
+    context "fedora #{fedora_version}" do
+      let(:version) { fedora_version }
+      let(:adapter) do
+        Valkyrie::Persistence::Fedora::MetadataAdapter.new(
+          fedora_adapter_config(base_path: "test_fed", schema: schema, fedora_version: version)
+        )
+      end
 
-  let(:resource)  { SampleResource.new(title: "My Title") }
-  let(:converter) { described_class.new(resource: resource, adapter: adapter) }
+      let(:resource)  { SampleResource.new(title: "My Title") }
+      let(:converter) { described_class.new(resource: resource, adapter: adapter) }
 
-  before do
-    class SampleResource < Valkyrie::Resource
-      include Valkyrie::Resource::AccessControls
-      attribute :title
-    end
-  end
+      before do
+        class SampleResource < Valkyrie::Resource
+          include Valkyrie::Resource::AccessControls
+          attribute :title
+        end
+      end
 
-  after do
-    Object.send(:remove_const, :SampleResource)
-  end
+      after do
+        Object.send(:remove_const, :SampleResource)
+      end
 
-  context "with the default schema" do
-    let(:schema) { Valkyrie::Persistence::Fedora::PermissiveSchema.new }
-    let(:query)  { converter.convert.graph.query(predicate: RDF::URI("http://example.com/predicate/title")) }
+      context "with the default schema" do
+        let(:schema) { Valkyrie::Persistence::Fedora::PermissiveSchema.new }
+        let(:query)  { converter.convert.graph.query(predicate: RDF::URI("http://example.com/predicate/title")) }
 
-    it "persists to Fedora using a fake predicate" do
-      expect(query.first.object.to_s).to eq("My Title")
-    end
-  end
+        it "persists to Fedora using a fake predicate" do
+          expect(query.first.object.to_s).to eq("My Title")
+        end
+      end
 
-  context "with a defined schema" do
-    let(:schema) { Valkyrie::Persistence::Fedora::PermissiveSchema.new(title: ::RDF::Vocab::DC.title) }
-    let(:query)  { converter.convert.graph.query(predicate: ::RDF::Vocab::DC.title) }
+      context "with a defined schema" do
+        let(:schema) { Valkyrie::Persistence::Fedora::PermissiveSchema.new(title: ::RDF::Vocab::DC.title) }
+        let(:query)  { converter.convert.graph.query(predicate: ::RDF::Vocab::DC.title) }
 
-    it "persists to Fedora using the defined predicate" do
-      expect(query.first.object.to_s).to eq("My Title")
+        it "persists to Fedora using the defined predicate" do
+          expect(query.first.object.to_s).to eq("My Title")
+        end
+      end
     end
   end
 end

--- a/spec/valkyrie/persistence/fedora/persister_spec.rb
+++ b/spec/valkyrie/persistence/fedora/persister_spec.rb
@@ -3,171 +3,178 @@ require 'spec_helper'
 require 'valkyrie/specs/shared_specs'
 
 RSpec.describe Valkyrie::Persistence::Fedora::Persister do
-  let(:adapter) do
-    Valkyrie::Persistence::Fedora::MetadataAdapter.new(
-      fedora_adapter_config(
-        base_path: "test_fed",
-        schema: Valkyrie::Persistence::Fedora::PermissiveSchema.new(title: RDF::URI("http://bad.com/title"))
-      )
-    )
-  end
-  let(:persister) { adapter.persister }
-  let(:query_service) { adapter.query_service }
-  it_behaves_like "a Valkyrie::Persister"
+  [4, 5].each do |fedora_version|
+    context "fedora #{fedora_version}" do
+      let(:fedora_version) { 4 }
 
-  context "when given an id containing a slash" do
-    before do
-      raise 'persister must be set with `let(:persister)`' unless defined? persister
-      class CustomResource < Valkyrie::Resource
-        include Valkyrie::Resource::AccessControls
-        attribute :title
-        attribute :author
-        attribute :member_ids
-        attribute :nested_resource
+      let(:adapter) do
+        Valkyrie::Persistence::Fedora::MetadataAdapter.new(
+          fedora_adapter_config(
+            base_path: "test_fed",
+            schema: Valkyrie::Persistence::Fedora::PermissiveSchema.new(title: RDF::URI("http://bad.com/title")),
+            fedora_version: fedora_version
+          )
+        )
       end
-    end
-    after do
-      Object.send(:remove_const, :CustomResource)
-    end
-    let(:resource_class) { CustomResource }
+      let(:persister) { adapter.persister }
+      let(:query_service) { adapter.query_service }
+      it_behaves_like "a Valkyrie::Persister"
 
-    it "can store the resource" do
-      id = Valkyrie::ID.new("test/default")
-      expect(id.to_s).to eq "test/default"
-      persister.save(resource: resource_class.new(id: id))
-      reloaded = query_service.find_by(id: id)
-      expect(reloaded.id).to eq id
-      expect(reloaded).to be_persisted
-    end
-  end
+      context "when given an id containing a slash" do
+        before do
+          raise 'persister must be set with `let(:persister)`' unless defined? persister
+          class CustomResource < Valkyrie::Resource
+            include Valkyrie::Resource::AccessControls
+            attribute :title
+            attribute :author
+            attribute :member_ids
+            attribute :nested_resource
+          end
+        end
+        after do
+          Object.send(:remove_const, :CustomResource)
+        end
+        let(:resource_class) { CustomResource }
 
-  context "when given multiple Times" do
-    before do
-      class CustomResource < Valkyrie::Resource
-        attribute :times
+        it "can store the resource" do
+          id = Valkyrie::ID.new("test/default")
+          expect(id.to_s).to eq "test/default"
+          persister.save(resource: resource_class.new(id: id))
+          reloaded = query_service.find_by(id: id)
+          expect(reloaded.id).to eq id
+          expect(reloaded).to be_persisted
+        end
       end
-    end
-    after do
-      Object.send(:remove_const, :CustomResource)
-    end
-    it "works" do
-      resource = CustomResource.new(times: [Time.now, Time.now - 5])
 
-      output = persister.save(resource: resource)
+      context "when given multiple Times" do
+        before do
+          class CustomResource < Valkyrie::Resource
+            attribute :times
+          end
+        end
+        after do
+          Object.send(:remove_const, :CustomResource)
+        end
+        it "works" do
+          resource = CustomResource.new(times: [Time.now, Time.now - 5])
 
-      expect(output.times).to be_a Array
-    end
-  end
+          output = persister.save(resource: resource)
 
-  context "when given an alternate identifier" do
-    before do
-      raise 'persister must be set with `let(:persister)`' unless defined? persister
-      class CustomResource < Valkyrie::Resource
-        include Valkyrie::Resource::AccessControls
-        attribute :alternate_ids, Valkyrie::Types::Array
-        attribute :title
-        attribute :author
-        attribute :member_ids
-        attribute :nested_resource
+          expect(output.times).to be_a Array
+        end
       end
-    end
-    after do
-      Object.send(:remove_const, :CustomResource)
-    end
-    let(:resource_class) { CustomResource }
 
-    it "creates an alternate identifier resource" do
-      alternate_identifier = Valkyrie::ID.new("alternative")
-      resource = resource_class.new
-      resource.alternate_ids = [alternate_identifier]
-      persister.save(resource: resource)
+      context "when given an alternate identifier" do
+        before do
+          raise 'persister must be set with `let(:persister)`' unless defined? persister
+          class CustomResource < Valkyrie::Resource
+            include Valkyrie::Resource::AccessControls
+            attribute :alternate_ids, Valkyrie::Types::Array
+            attribute :title
+            attribute :author
+            attribute :member_ids
+            attribute :nested_resource
+          end
+        end
+        after do
+          Object.send(:remove_const, :CustomResource)
+        end
+        let(:resource_class) { CustomResource }
 
-      alternate = query_service.find_by(id: alternate_identifier)
-      expect(alternate.id).to eq alternate_identifier
-      expect(alternate).to be_persisted
-    end
+        it "creates an alternate identifier resource" do
+          alternate_identifier = Valkyrie::ID.new("alternative")
+          resource = resource_class.new
+          resource.alternate_ids = [alternate_identifier]
+          persister.save(resource: resource)
 
-    it "updates an alternate identifier resource" do
-      alternate_identifier = Valkyrie::ID.new("alternative")
-      resource = resource_class.new
-      resource.alternate_ids = [alternate_identifier]
-      reloaded = persister.save(resource: resource)
+          alternate = query_service.find_by(id: alternate_identifier)
+          expect(alternate.id).to eq alternate_identifier
+          expect(alternate).to be_persisted
+        end
 
-      alternate = query_service.find_by(id: alternate_identifier)
-      expect(alternate.id).to eq alternate_identifier
-      expect(alternate).to be_persisted
+        it "updates an alternate identifier resource" do
+          alternate_identifier = Valkyrie::ID.new("alternative")
+          resource = resource_class.new
+          resource.alternate_ids = [alternate_identifier]
+          reloaded = persister.save(resource: resource)
 
-      alternate_identifier = Valkyrie::ID.new("alternate")
-      reloaded.alternate_ids = [alternate_identifier]
-      persister.save(resource: reloaded)
-      expect(query_service.find_by_alternate_identifier(alternate_identifier: alternate_identifier).id).to eq reloaded.id
-    end
+          alternate = query_service.find_by(id: alternate_identifier)
+          expect(alternate.id).to eq alternate_identifier
+          expect(alternate).to be_persisted
 
-    it "deletes the alternate identifier with the resource" do
-      alternate_identifier = Valkyrie::ID.new("alternative")
-      resource = resource_class.new
-      resource.alternate_ids = [alternate_identifier]
-      reloaded = persister.save(resource: resource)
+          alternate_identifier = Valkyrie::ID.new("alternate")
+          reloaded.alternate_ids = [alternate_identifier]
+          persister.save(resource: reloaded)
+          expect(query_service.find_by_alternate_identifier(alternate_identifier: alternate_identifier).id).to eq reloaded.id
+        end
 
-      alternate = query_service.find_by(id: alternate_identifier)
-      expect(alternate.id).to eq alternate_identifier
-      expect(alternate).to be_persisted
+        it "deletes the alternate identifier with the resource" do
+          alternate_identifier = Valkyrie::ID.new("alternative")
+          resource = resource_class.new
+          resource.alternate_ids = [alternate_identifier]
+          reloaded = persister.save(resource: resource)
 
-      persister.delete(resource: reloaded)
-      expect { query_service.find_by(id: alternate_identifier) }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
-    end
+          alternate = query_service.find_by(id: alternate_identifier)
+          expect(alternate.id).to eq alternate_identifier
+          expect(alternate).to be_persisted
 
-    it "deletes removed alternate identifiers" do
-      alternate_identifier = Valkyrie::ID.new("altfirst")
-      second_alternate_identifier = Valkyrie::ID.new("altsecond")
-      resource = resource_class.new
-      resource.alternate_ids = [alternate_identifier, second_alternate_identifier]
-      reloaded = persister.save(resource: resource)
+          persister.delete(resource: reloaded)
+          expect { query_service.find_by(id: alternate_identifier) }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
+        end
 
-      alternate = query_service.find_by(id: second_alternate_identifier)
-      expect(alternate.id).to eq second_alternate_identifier
-      expect(alternate).to be_persisted
+        it "deletes removed alternate identifiers" do
+          alternate_identifier = Valkyrie::ID.new("altfirst")
+          second_alternate_identifier = Valkyrie::ID.new("altsecond")
+          resource = resource_class.new
+          resource.alternate_ids = [alternate_identifier, second_alternate_identifier]
+          reloaded = persister.save(resource: resource)
 
-      reload = query_service.find_by(id: reloaded.id)
-      reload.alternate_ids = [alternate_identifier]
-      persister.save(resource: reload)
+          alternate = query_service.find_by(id: second_alternate_identifier)
+          expect(alternate.id).to eq second_alternate_identifier
+          expect(alternate).to be_persisted
 
-      alternate = query_service.find_by(id: alternate_identifier)
-      expect(alternate.id).to eq alternate_identifier
-      expect(alternate).to be_persisted
+          reload = query_service.find_by(id: reloaded.id)
+          reload.alternate_ids = [alternate_identifier]
+          persister.save(resource: reload)
 
-      expect { query_service.find_by(id: second_alternate_identifier) }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
-    end
-  end
+          alternate = query_service.find_by(id: alternate_identifier)
+          expect(alternate.id).to eq alternate_identifier
+          expect(alternate).to be_persisted
 
-  context "using Fedora's builtin optimistic locking" do
-    before do
-      class FedoraLockingResource < Valkyrie::Resource
-        enable_optimistic_locking
-        attribute :title
+          expect { query_service.find_by(id: second_alternate_identifier) }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
+        end
       end
-    end
 
-    after do
-      ActiveSupport::Dependencies.remove_constant("FedoraLockingResource")
-    end
+      context "using Fedora's builtin optimistic locking" do
+        before do
+          class FedoraLockingResource < Valkyrie::Resource
+            enable_optimistic_locking
+            attribute :title
+          end
+        end
 
-    it "does not raise an error when the object hasn't been updated by another client" do
-      resource = persister.save(resource: FedoraLockingResource.new(title: ["Fedora Locking Resource"]))
-      expect { persister.save(resource: resource) }.not_to raise_error
-    end
-    it "raises an error when saving an object that has been updated by another client" do
-      resource = persister.save(resource: FedoraLockingResource.new(title: ["Fedora Locking Resource"]))
+        after do
+          ActiveSupport::Dependencies.remove_constant("FedoraLockingResource")
+        end
 
-      # update a copy of the resource directly with orm to make sure our last-modified date is stale
-      # but without invalidating our optimistic lock token
-      sleep 1
-      other_resource = resource.dup
-      other_resource.title = ["Updated Locking Resource"]
-      orm = adapter.resource_factory.from_resource(resource: other_resource)
-      orm.update { |req| req.headers["Prefer"] = "handling=lenient; received=\"minimal\"" }
+        it "does not raise an error when the object hasn't been updated by another client" do
+          resource = persister.save(resource: FedoraLockingResource.new(title: ["Fedora Locking Resource"]))
+          expect { persister.save(resource: resource) }.not_to raise_error
+        end
+        it "raises an error when saving an object that has been updated by another client" do
+          resource = persister.save(resource: FedoraLockingResource.new(title: ["Fedora Locking Resource"]))
 
-      expect { persister.save(resource: resource) }.to raise_error(Valkyrie::Persistence::StaleObjectError, "The object #{resource.id} has been updated by another process.")
+          # update a copy of the resource directly with orm to make sure our last-modified date is stale
+          # but without invalidating our optimistic lock token
+          sleep 1
+          other_resource = resource.dup
+          other_resource.title = ["Updated Locking Resource"]
+          orm = adapter.resource_factory.from_resource(resource: other_resource)
+          orm.update { |req| req.headers["Prefer"] = "handling=lenient; received=\"minimal\"" }
+
+          expect { persister.save(resource: resource) }.to raise_error(Valkyrie::Persistence::StaleObjectError, "The object #{resource.id} has been updated by another process.")
+        end
+      end
     end
   end
 end

--- a/spec/valkyrie/persistence/fedora/persister_spec.rb
+++ b/spec/valkyrie/persistence/fedora/persister_spec.rb
@@ -5,9 +5,10 @@ require 'valkyrie/specs/shared_specs'
 RSpec.describe Valkyrie::Persistence::Fedora::Persister do
   let(:adapter) do
     Valkyrie::Persistence::Fedora::MetadataAdapter.new(
-      connection: ::Ldp::Client.new("http://localhost:8988/rest"),
-      base_path: "test_fed",
-      schema: Valkyrie::Persistence::Fedora::PermissiveSchema.new(title: RDF::URI("http://bad.com/title"))
+      fedora_adapter_config(
+        base_path: "test_fed",
+        schema: Valkyrie::Persistence::Fedora::PermissiveSchema.new(title: RDF::URI("http://bad.com/title"))
+      )
     )
   end
   let(:persister) { adapter.persister }

--- a/spec/valkyrie/persistence/fedora/persister_spec.rb
+++ b/spec/valkyrie/persistence/fedora/persister_spec.rb
@@ -5,14 +5,14 @@ require 'valkyrie/specs/shared_specs'
 RSpec.describe Valkyrie::Persistence::Fedora::Persister do
   [4, 5].each do |fedora_version|
     context "fedora #{fedora_version}" do
-      let(:fedora_version) { 4 }
+      let(:version) { 4 }
 
       let(:adapter) do
         Valkyrie::Persistence::Fedora::MetadataAdapter.new(
           fedora_adapter_config(
             base_path: "test_fed",
             schema: Valkyrie::Persistence::Fedora::PermissiveSchema.new(title: RDF::URI("http://bad.com/title")),
-            fedora_version: fedora_version
+            fedora_version: version
           )
         )
       end

--- a/spec/valkyrie/persistence/fedora/query_service_spec.rb
+++ b/spec/valkyrie/persistence/fedora/query_service_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 require 'valkyrie/specs/shared_specs'
 
 RSpec.describe Valkyrie::Persistence::Fedora::QueryService do
-  let(:adapter) { Valkyrie::Persistence::Fedora::MetadataAdapter.new(connection: ::Ldp::Client.new("http://localhost:8988/rest"), base_path: "test_fed") }
+  let(:adapter) { Valkyrie::Persistence::Fedora::MetadataAdapter.new(fedora_adapter_config(base_path: "test_fed")) }
   let(:persister) { adapter.persister }
   let(:query_service) { adapter.query_service }
   it_behaves_like "a Valkyrie query provider"

--- a/spec/valkyrie/persistence/fedora/query_service_spec.rb
+++ b/spec/valkyrie/persistence/fedora/query_service_spec.rb
@@ -3,8 +3,13 @@ require 'spec_helper'
 require 'valkyrie/specs/shared_specs'
 
 RSpec.describe Valkyrie::Persistence::Fedora::QueryService do
-  let(:adapter) { Valkyrie::Persistence::Fedora::MetadataAdapter.new(fedora_adapter_config(base_path: "test_fed")) }
-  let(:persister) { adapter.persister }
-  let(:query_service) { adapter.query_service }
-  it_behaves_like "a Valkyrie query provider"
+  [4, 5].each do |fedora_version|
+    context "fedora #{fedora_version}" do
+      let(:version) { fedora_version }
+      let(:adapter) { Valkyrie::Persistence::Fedora::MetadataAdapter.new(fedora_adapter_config(base_path: "test_fed", fedora_version: version)) }
+      let(:persister) { adapter.persister }
+      let(:query_service) { adapter.query_service }
+      it_behaves_like "a Valkyrie query provider"
+    end
+  end
 end

--- a/spec/valkyrie/persistence/solr/persister_spec.rb
+++ b/spec/valkyrie/persistence/solr/persister_spec.rb
@@ -64,8 +64,8 @@ RSpec.describe Valkyrie::Persistence::Solr::Persister do
     let(:resource_class) { CustomResource }
 
     it "Returns a string when DateTime conversion fails" do
-      time1 = DateTime.current
-      time2 = Time.current.in_time_zone
+      time1 = DateTime.current.utc
+      time2 = Time.current.utc
       allow(DateTime).to receive(:iso8601).and_raise StandardError.new("bogus exception")
       book = persister.save(resource: resource_class.new(title: [time1], author: [time2]))
 

--- a/spec/valkyrie/storage/fedora_spec.rb
+++ b/spec/valkyrie/storage/fedora_spec.rb
@@ -4,13 +4,27 @@ require 'valkyrie/specs/shared_specs'
 include ActionDispatch::TestProcess
 
 RSpec.describe Valkyrie::Storage::Fedora do
-  before(:all) do
-    # Start from a clean fedora
-    wipe_fedora!(base_path: "test")
+  context "fedora 4" do
+    before(:all) do
+      # Start from a clean fedora
+      wipe_fedora!(base_path: "test", fedora_version: 4)
+    end
+
+    let(:storage_adapter) { described_class.new(fedora_adapter_config(base_path: 'test', fedora_version: 4)) }
+    let(:file) { fixture_file_upload('files/example.tif', 'image/tiff') }
+
+    it_behaves_like "a Valkyrie::StorageAdapter"
   end
 
-  let(:storage_adapter) { described_class.new(fedora_adapter_config(base_path: 'test')) }
-  let(:file) { fixture_file_upload('files/example.tif', 'image/tiff') }
+  context "fedora 5" do
+    before(:all) do
+      # Start from a clean fedora
+      wipe_fedora!(base_path: "test", fedora_version: 5)
+    end
 
-  it_behaves_like "a Valkyrie::StorageAdapter"
+    let(:storage_adapter) { described_class.new(fedora_adapter_config(base_path: 'test', fedora_version: 5)) }
+    let(:file) { fixture_file_upload('files/example.tif', 'image/tiff') }
+
+    it_behaves_like "a Valkyrie::StorageAdapter"
+  end
 end

--- a/spec/valkyrie/storage/fedora_spec.rb
+++ b/spec/valkyrie/storage/fedora_spec.rb
@@ -6,14 +6,10 @@ include ActionDispatch::TestProcess
 RSpec.describe Valkyrie::Storage::Fedora do
   before(:all) do
     # Start from a clean fedora
-    Valkyrie::Persistence::Fedora::MetadataAdapter.new(
-      connection: ::Ldp::Client.new("http://localhost:8988/rest"),
-      base_path: "test"
-    ).persister.wipe!
+    wipe_fedora!(base_path: "test")
   end
 
-  let(:connection) { ::Ldp::Client.new("http://localhost:8988/rest") }
-  let(:storage_adapter) { described_class.new(connection: connection, base_path: 'test') }
+  let(:storage_adapter) { described_class.new(fedora_adapter_config(base_path: 'test')) }
   let(:file) { fixture_file_upload('files/example.tif', 'image/tiff') }
 
   it_behaves_like "a Valkyrie::StorageAdapter"

--- a/tasks/dev.rake
+++ b/tasks/dev.rake
@@ -50,8 +50,8 @@ namespace :server do
   end
 
   def shared_fedora_opts
-    opts = { managed: true, verbose: true, enable_jms: false, download_dir: "tmp" }
-    opts[:version] = ENV['FCREPO_VERSION'] if ENV['FCREPO_VERSION']
+    opts = { managed: true, verbose: true, enable_jms: false, download_dir: "tmp", validate: false }
+    opts[:version] = "5.0.0-RC1"
     opts
   end
 end

--- a/tasks/dev.rake
+++ b/tasks/dev.rake
@@ -50,8 +50,8 @@ namespace :server do
   end
 
   def shared_fedora_opts
-    opts = { managed: true, verbose: true, enable_jms: false, download_dir: "tmp", validate: false }
-    opts[:version] = "5.0.0-RC1"
+    opts = { managed: true, verbose: true, enable_jms: false, download_dir: "tmp" }
+    opts[:version] = ENV['FCREPO_VERSION'] if ENV['FCREPO_VERSION']
     opts
   end
 end

--- a/tasks/dev.rake
+++ b/tasks/dev.rake
@@ -7,10 +7,12 @@ namespace :server do
     require 'fcrepo_wrapper'
     SolrWrapper.wrap(shared_solr_opts.merge(port: 8984, instance_dir: 'tmp/blacklight-core-test')) do |solr|
       solr.with_collection(name: "blacklight-core-test", dir: Pathname.new(__dir__).join("..", "solr", "config").to_s) do
-        FcrepoWrapper.wrap(shared_fedora_opts.merge(port: 8988, fcrepo_home_dir: "tmp/fcrepo4-test-data")) do |_fcrepo|
-          puts "Setup solr & fedora."
-          loop do
-            sleep(1)
+        FcrepoWrapper.wrap(shared_fedora_opts.merge(port: 8988, fcrepo_home_dir: "tmp/fcrepo4-test-data", version: "4.7.5", instance_directory: "tmp/fcrepo4")) do |_fcrepo|
+          FcrepoWrapper::Instance.new(shared_fedora_opts.merge(port: 8998, fcrepo_home_dir: "tmp/fcrepo5-test-data", version: "5.0.0-RC-1", instance_directory: "tmp/fcrepo5")).wrap do |_other_repo|
+            puts "Setup solr & Fedora"
+            loop do
+              sleep(1)
+            end
           end
         end
       end
@@ -22,7 +24,8 @@ namespace :server do
     require 'solr_wrapper'
     require 'fcrepo_wrapper'
     SolrWrapper.instance(shared_solr_opts.merge(port: 8984, instance_dir: 'tmp/blacklight-core-test')).remove_instance_dir!
-    FcrepoWrapper.default_instance(shared_fedora_opts.merge(port: 8988, fcrepo_home_dir: "tmp/fcrepo4-test-data")).remove_instance_dir!
+    FcrepoWrapper.default_instance(shared_fedora_opts.merge(port: 8988, fcrepo_home_dir: "tmp/fcrepo4-test-data", instance_directory: "tmp/fcrepo4")).remove_instance_dir!
+    FcrepoWrapper::Instance.new(shared_fedora_opts.merge(port: 8998, fcrepo_home_dir: "tmp/fcrepo5-test-data", instance_directory: "tmp/fcrepo5")).remove_instance_dir!
     puts "Cleaned up test solr & fedora servers."
   end
 
@@ -33,10 +36,12 @@ namespace :server do
 
     SolrWrapper.wrap(shared_solr_opts.merge(port: 8983, instance_dir: 'tmp/blacklight-core')) do |solr|
       solr.with_collection(name: "blacklight-core", dir: Pathname.new(__dir__).join("..", "solr", "config").to_s) do
-        FcrepoWrapper.wrap(shared_fedora_opts.merge(port: 8986, fcrepo_home_dir: "fcrepo4-dev-data")) do |_fcrepo|
-          puts "Setup Solr & Fedora"
-          loop do
-            sleep(1)
+        FcrepoWrapper.wrap(shared_fedora_opts.merge(port: 8986, fcrepo_home_dir: "tmp/fcrepo4-dev-data", version: "4.7.5")) do |_fcrepo|
+          FcrepoWrapper::Instance.new(shared_fedora_opts.merge(port: 8996, fcrepo_home_dir: "tmp/fcrepo5-dev-data", version: "5.0.0-RC-1")).wrap do |_fcrepo|
+            puts "Setup solr & Fedora"
+            loop do
+              sleep(1)
+            end
           end
         end
       end
@@ -51,7 +56,6 @@ namespace :server do
 
   def shared_fedora_opts
     opts = { managed: true, verbose: true, enable_jms: false, download_dir: "tmp" }
-    opts[:version] = ENV['FCREPO_VERSION'] if ENV['FCREPO_VERSION']
     opts
   end
 end


### PR DESCRIPTION
Adds Fedora 5 compatibility, via a new `fedora_version` parameter to the Fedora metadata and storage adapters.