### PR TITLE
Implement Deprecations in Preparation for Valkyrie 2.0

### DIFF
--- a/lib/valkyrie/persistence/fedora/persister.rb
+++ b/lib/valkyrie/persistence/fedora/persister.rb
@@ -165,7 +165,7 @@ module Valkyrie::Persistence::Fedora
       # @return [Valkyrie::Persistence::OptimisticLockToken]
       def native_lock_token(resource)
         return unless resource.optimistic_locking_enabled?
-        resource[Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK].find { |lock_token| lock_token.adapter_id == "native-#{adapter.id}" }
+        resource[Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK].find { |lock_token| lock_token.adapter_id.to_s == "native-#{adapter.id}" }
       end
 
       # Set Fedora request headers:

--- a/lib/valkyrie/persistence/fedora/persister/model_converter.rb
+++ b/lib/valkyrie/persistence/fedora/persister/model_converter.rb
@@ -296,7 +296,7 @@ module Valkyrie::Persistence::Fedora
         # @param [Object] value
         # @return [Boolean]
         def self.handles?(value)
-          value.is_a?(Property) && value.value.is_a?(Hash) && value.value[:internal_resource]
+          value.is_a?(Property) && (value.value.is_a?(Hash) || value.value.is_a?(Valkyrie::Resource)) && value.value[:internal_resource]
         end
 
         # Generate a new parent graph containing the child graph generated from the ModelConverter::Property objects

--- a/lib/valkyrie/persistence/memory/query_service.rb
+++ b/lib/valkyrie/persistence/memory/query_service.rb
@@ -113,11 +113,7 @@ module Valkyrie::Persistence::Memory
     def find_inverse_references_by(resource:, property:)
       ensure_persisted(resource)
       find_all.select do |obj|
-        begin
-          Array.wrap(obj[property]).include?(resource.id)
-        rescue
-          nil
-        end
+        Array.wrap(obj[property]).include?(resource.id)
       end
     end
 

--- a/lib/valkyrie/persistence/memory/query_service.rb
+++ b/lib/valkyrie/persistence/memory/query_service.rb
@@ -36,7 +36,7 @@ module Valkyrie::Persistence::Memory
     def find_by_alternate_identifier(alternate_identifier:)
       alternate_identifier = Valkyrie::ID.new(alternate_identifier.to_s) if alternate_identifier.is_a?(String)
       validate_id(alternate_identifier)
-      cache.select { |_key, resource| resource['alternate_ids'].include?(alternate_identifier) }.values.first || raise(::Valkyrie::Persistence::ObjectNotFoundError)
+      cache.select { |_key, resource| resource[:alternate_ids].include?(alternate_identifier) }.values.first || raise(::Valkyrie::Persistence::ObjectNotFoundError)
     end
 
     # Get a batch of resources by ID.
@@ -116,7 +116,7 @@ module Valkyrie::Persistence::Memory
         begin
           Array.wrap(obj[property]).include?(resource.id)
         rescue
-          false
+          nil
         end
       end
     end

--- a/lib/valkyrie/persistence/solr/model_converter.rb
+++ b/lib/valkyrie/persistence/solr/model_converter.rb
@@ -222,7 +222,7 @@ module Valkyrie::Persistence::Solr
         # @param [Object] value
         # @return [Boolean]
         def self.handles?(value)
-          value.value.is_a?(Hash)
+          value.value.is_a?(Hash) || value.value.is_a?(Valkyrie::Resource)
         end
 
         # Constructs a SolrRow object for a Property with a Hash value

--- a/lib/valkyrie/resource.rb
+++ b/lib/valkyrie/resource.rb
@@ -97,9 +97,55 @@ module Valkyrie
       self.class.optimistic_locking_enabled?
     end
 
+    class DeprecatedHashWrite < Hash
+      def []=(_k, _v)
+        if @soft_frozen
+          warn "[DEPRECATION] Writing directly to attributes has been deprecated." \
+            " Please use #set_value(k, v) instead or #dup first." \
+            " In the next major version, this hash will be frozen. \n" \
+            "Called from #{Gem.location_of_caller.join(':')}"
+        end
+        super
+      end
+
+      def delete(*_args)
+        if @soft_frozen
+          warn "[DEPRECATION] Writing directly to attributes has been deprecated." \
+            " Please use #set_value(k, v) instead or #dup first." \
+            " In the next major version, this hash will be frozen. \n" \
+            "Called from #{Gem.location_of_caller.join(':')}"
+        end
+        super
+      end
+
+      def delete_if(*_args)
+        if @soft_frozen
+          warn "[DEPRECATION] Writing directly to attributes has been deprecated." \
+            " Please use #set_value(k, v) instead or #dup first." \
+            " In the next major version, this hash will be frozen. \n" \
+            "Called from #{Gem.location_of_caller.join(':')}"
+        end
+        super
+      end
+
+      def soft_freeze!
+        @soft_frozen = true
+        self
+      end
+
+      def soft_thaw!
+        @soft_frozen = false
+        self
+      end
+
+      def dup
+        super.soft_thaw!
+      end
+    end
+
     # @return [Hash] Hash of attributes
     def attributes
-      to_h.freeze
+      DeprecatedHashWrite.new.merge(to_h).soft_freeze!
     end
 
     # @param name [Symbol] Attribute name

--- a/lib/valkyrie/specs/shared_specs/resource.rb
+++ b/lib/valkyrie/specs/shared_specs/resource.rb
@@ -137,7 +137,10 @@ RSpec.shared_examples 'a Valkyrie::Resource' do
 
       expect(resource.attributes).to have_key(:bla)
       expect(resource.attributes[:internal_resource]).to eq resource_klass.to_s
-      expect { resource.attributes[:internal_resource] = "bla" }.to raise_error "can't modify frozen Hash"
+      expect { resource.attributes[:internal_resource] = "bla" }.to output(/\[DEPRECATION\]/).to_stderr
+      expect { resource.attributes.delete_if { true } }.to output(/\[DEPRECATION\]/).to_stderr
+      expect { resource.attributes.delete(:internal_resource) }.to output(/\[DEPRECATION\]/).to_stderr
+      expect { resource.attributes.dup[:internal_resource] = "bla" }.not_to output.to_stderr
 
       resource_klass.schema.delete(:bla)
     end

--- a/lib/valkyrie/specs/shared_specs/resource.rb
+++ b/lib/valkyrie/specs/shared_specs/resource.rb
@@ -90,7 +90,6 @@ RSpec.shared_examples 'a Valkyrie::Resource' do
       resource.other_property = "test"
 
       expect(resource["other_property"]).to eq ["test"]
-      expect { resource["other_property"] }.to output(/\[DEPRECATION\]/).to_stderr
       resource_klass.schema.delete(:other_property)
     end
   end
@@ -121,8 +120,8 @@ RSpec.shared_examples 'a Valkyrie::Resource' do
     it "can set values with string properties, but will throw a deprecation error" do
       resource_klass.attribute :string_property
 
-      resource = resource_klass.new("string_property" => "bla")
-      expect { resource_klass.new("string_property" => "bla") }.to output(/\[DEPRECATION\]/).to_stderr
+      resource = nil
+      expect { resource = resource_klass.new("string_property" => "bla") }.to output(/\[DEPRECATION\]/).to_stderr
 
       expect(resource.string_property).to eq ["bla"]
       resource_klass.schema.delete(:string_property)

--- a/lib/valkyrie/types.rb
+++ b/lib/valkyrie/types.rb
@@ -98,5 +98,21 @@ module Valkyrie
     SingleValuedString = Valkyrie::Types::String.constructor do |value|
       ::Array.wrap(value).first.to_s
     end
+    Valkyrie::Types::Integer = Dry::Types["int"]
+    Valkyrie::Types::Coercible::Integer = Dry::Types["coercible.int"]
+    Int = Dry::Types["int"].constructor do |value|
+      warn "[DEPRECATION] Valkyrie::Types::Int has been renamed in dry-types and this " \
+           "reference will be removed in the next major version of Valkyrie. Please use " \
+           "Valkyrie::Types::Integer instead. " \
+           "Called from #{Gem.location_of_caller.join(':')}"
+      Dry::Types["int"][value]
+    end
+    Coercible::Int = Dry::Types["coercible.int"].constructor do |value|
+      warn "[DEPRECATION] Valkyrie::Types::Coercible::Int has been renamed in dry-types and this " \
+           "reference will be removed in the next major version of Valkyrie. Please use " \
+           "Valkyrie::Types::Coercible::Integer instead. " \
+           "Called from #{Gem.location_of_caller.join(':')}"
+      Dry::Types["coercible.int"][value]
+    end
   end
 end

--- a/spec/valkyrie/persistence/solr/model_converter_spec.rb
+++ b/spec/valkyrie/persistence/solr/model_converter_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Valkyrie::Persistence::Solr::ModelConverter do
       attribute :author, Valkyrie::Types::Set
       attribute :birthday, Valkyrie::Types::DateTime.optional
       attribute :creator, Valkyrie::Types::String
+      attribute :birthdate, Valkyrie::Types::DateTime.optional
     end
   end
   after do
@@ -22,6 +23,9 @@ RSpec.describe Valkyrie::Persistence::Solr::ModelConverter do
     instance_double(Resource,
                     id: "1",
                     internal_resource: 'Resource',
+                    title: ["Test", RDF::Literal.new("French", language: :fr)],
+                    author: ["Author"],
+                    creator: "Creator",
                     attributes:
                     {
                       created_at: created_at,
@@ -74,6 +78,7 @@ RSpec.describe Valkyrie::Persistence::Solr::ModelConverter do
       instance_double(Resource,
                       id: "1",
                       internal_resource: 'Resource',
+                      birthdate: Date.parse('1930-10-20'),
                       attributes:
                       {
                         internal_resource: 'Resource',

--- a/spec/valkyrie/resource_spec.rb
+++ b/spec/valkyrie/resource_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'spec_helper'
+require 'valkyrie/specs/shared_specs'
 
 RSpec.describe Valkyrie::Resource do
   before do
@@ -11,9 +12,11 @@ RSpec.describe Valkyrie::Resource do
     Object.send(:remove_const, :Resource)
   end
   subject(:resource) { Resource.new }
+  let(:resource_klass) { Resource }
+  it_behaves_like "a Valkyrie::Resource"
   describe "#fields" do
     it "returns all configured fields as an array of symbols" do
-      expect(Resource.fields).to eq [:id, :internal_resource, :created_at, :updated_at, :title]
+      expect(Resource.fields).to contain_exactly :id, :internal_resource, :created_at, :updated_at, :title
     end
   end
 
@@ -106,8 +109,9 @@ RSpec.describe Valkyrie::Resource do
     end
     describe "defining an internal attribute" do
       it "warns you and changes the type" do
-        expect { MyResource.attribute(:id) }.to output(/is a reserved attribute/).to_stderr
-        expect(MyResource.schema[:id]).to eq Valkyrie::Types::Set.optional
+        old_type = MyResource.schema[:id]
+        expect { MyResource.attribute(:id, Valkyrie::Types::Set) }.to output(/is a reserved attribute/).to_stderr
+        expect(MyResource.schema[:id]).not_to eq old_type
       end
     end
   end

--- a/spec/valkyrie/types_spec.rb
+++ b/spec/valkyrie/types_spec.rb
@@ -135,4 +135,18 @@ RSpec.describe Valkyrie::Types do
       expect(resource.my_flag).to be true
     end
   end
+
+  describe "The INT type" do
+    it "works, but says it's deprecated" do
+      expect { Valkyrie::Types::Int[1] }.to output(/DEPRECATION/).to_stderr
+      expect { Valkyrie::Types::Coercible::Int[1] }.to output(/DEPRECATION/).to_stderr
+    end
+  end
+
+  describe "the INTEGER type" do
+    it "works and doesn't say it's deprecated" do
+      expect { Valkyrie::Types::Integer[1] }.not_to output(/DEPRECATION/).to_stderr
+      expect { Valkyrie::Types::Coercible::Integer[1] }.not_to output(/DEPRECATION/).to_stderr
+    end
+  end
 end


### PR DESCRIPTION
These are deprecations we've discovered are necessary via upgrading to the latest version of dry-struct.