### PR TITLE
Add Valkyrie::Types::Params::ID

### DIFF
--- a/lib/valkyrie/types.rb
+++ b/lib/valkyrie/types.rb
@@ -29,6 +29,16 @@ module Valkyrie
       end
     end
 
+    module Params
+      ID = Valkyrie::Types::ID.constructor do |input|
+        if input.blank?
+          nil
+        else
+          Valkyrie::Types::ID[input]
+        end
+      end
+    end
+
     # Valkyrie::URI
     URI = Dry::Types::Definition
           .new(RDF::URI)

--- a/spec/valkyrie/types_spec.rb
+++ b/spec/valkyrie/types_spec.rb
@@ -49,6 +49,19 @@ RSpec.describe Valkyrie::Types do
     end
   end
 
+  describe "Valkyrie::Types::Params::ID" do
+    context "when a blank string is passed in" do
+      it "returns nil" do
+        expect(Valkyrie::Types::Params::ID[""]).to eq nil
+      end
+    end
+    context "when passed a string" do
+      it "returns a Valkyrie::Types::ID" do
+        expect(Valkyrie::Types::Params::ID["test"]).to be_a Valkyrie::ID
+      end
+    end
+  end
+
   describe 'The URI Type' do
     it 'returns an RDF::URI' do
       # We don't want to modify the defaults in the schema.


### PR DESCRIPTION
This handles blank-string casting from HTML forms.

Closes #605.