### PR TITLE
Remove :string_property from the test resource

### DIFF
--- a/lib/valkyrie/specs/shared_specs/resource.rb
+++ b/lib/valkyrie/specs/shared_specs/resource.rb
@@ -122,6 +122,7 @@ RSpec.shared_examples 'a Valkyrie::Resource' do
 
       resource = nil
       expect(resource).not_to respond_to :string_property
+      resource_klass.schema.delete(:string_property)
     end
   end
 


### PR DESCRIPTION
This was causing issues with shared specs because the :string_property attribute was still defined on the sample resource.

Fixes #641 