### PR TITLE
Enforce updated_at being set correctly.

### DIFF
--- a/lib/valkyrie/persistence/solr/model_converter.rb
+++ b/lib/valkyrie/persistence/solr/model_converter.rb
@@ -41,8 +41,16 @@ module Valkyrie::Persistence::Solr
       if resource_attributes[:created_at]
         DateTime.parse(resource_attributes[:created_at].to_s).utc.iso8601
       else
-        Time.current.utc.iso8601
+        Time.current.utc.iso8601(6)
       end
+    end
+
+    # @return [String] ISO-8601 timestamp in UTC of the updated_at for solr
+    # @note Solr stores its own updated_at timestamp, but for performance
+    # reasons we're generating our own. Without doing so, every time we add a
+    # new document we'd have to do a GET to find out the timestamp.
+    def updated_at
+      Time.current.utc.iso8601(6)
     end
 
     # @return [Hash] Solr document to index.
@@ -50,7 +58,8 @@ module Valkyrie::Persistence::Solr
       {
         "id": id,
         "join_id_ssi": "id-#{id}",
-        "created_at_dtsi": created_at
+        "created_at_dtsi": created_at,
+        "updated_at_dtsi": updated_at
       }.merge(add_single_values(attribute_hash)).merge(lock_hash)
     end
 

--- a/lib/valkyrie/persistence/solr/orm_converter.rb
+++ b/lib/valkyrie/persistence/solr/orm_converter.rb
@@ -54,7 +54,7 @@ module Valkyrie::Persistence::Solr
     # Construct a Time object from the datestamp for the date of the last resource update indexed in Solr
     # @return [Time]
     def updated_at
-      DateTime.parse(solr_document["timestamp"] || solr_document.fetch("created_at_dtsi").to_s).utc
+      DateTime.parse(solr_document.fetch("updated_at_dtsi").to_s || solr_document["timestamp"] || solr_document.fetch("created_at_dtsi").to_s).utc
     end
 
     # Construct the OptimisticLockToken object using the "_version_" field value in the Solr Document

--- a/lib/valkyrie/specs/shared_specs/persister.rb
+++ b/lib/valkyrie/specs/shared_specs/persister.rb
@@ -92,6 +92,7 @@ RSpec.shared_examples 'a Valkyrie::Persister' do |*flags|
     expect(book.updated_at).not_to be_blank
     expect(book.created_at).not_to be_kind_of Array
     expect(book.updated_at).not_to be_kind_of Array
+    expect(book.updated_at > book.created_at).to eq true
   end
 
   it "can handle Boolean RDF properties" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,7 @@ require "valkyrie"
 require 'pry'
 require 'action_dispatch'
 require 'webmock/rspec'
+require 'timecop'
 
 SOLR_TEST_URL = "http://127.0.0.1:#{ENV['TEST_JETTY_PORT'] || 8984}/solr/blacklight-core-test"
 

--- a/spec/valkyrie/persistence/solr/model_converter_spec.rb
+++ b/spec/valkyrie/persistence/solr/model_converter_spec.rb
@@ -40,6 +40,12 @@ RSpec.describe Valkyrie::Persistence::Solr::ModelConverter do
   end
 
   describe "#to_h" do
+    before do
+      Timecop.freeze
+    end
+    after do
+      Timecop.return
+    end
     it "maps all available properties to the solr record" do
       expect(mapper.convert!).to eq(
         id: resource.id.to_s,
@@ -60,6 +66,7 @@ RSpec.describe Valkyrie::Persistence::Solr::ModelConverter do
         author_tesi: ["Author"],
         author_tsi: ["Author"],
         created_at_dtsi: created_at.iso8601,
+        updated_at_dtsi: Time.current.utc.iso8601(6),
         internal_resource_ssim: ["Resource"],
         internal_resource_tesim: ["Resource"],
         internal_resource_tsim: ["Resource"],

--- a/valkyrie.gemspec
+++ b/valkyrie.gemspec
@@ -50,4 +50,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'fcrepo_wrapper'
   spec.add_development_dependency 'docker-stack', '~> 0.2.6'
   spec.add_development_dependency 'activerecord', '~> 5.1.0'
+  spec.add_development_dependency 'timecop'
 end


### PR DESCRIPTION
This also changes the Solr adapter to handle creating its own updated_at
too, but will be backwards compatible with previous assumptions of using
"timestamp."

Closes #639