### PR TITLE
Use Set.of(ID) in spec models to model good modeling to ensure casting.

### DIFF
--- a/lib/valkyrie/specs/shared_specs/queries.rb
+++ b/lib/valkyrie/specs/shared_specs/queries.rb
@@ -4,7 +4,7 @@ RSpec.shared_examples 'a Valkyrie query provider' do
     raise 'adapter must be set with `let(:adapter)`' unless
       defined? adapter
     class CustomResource < Valkyrie::Resource
-      attribute :alternate_ids, Valkyrie::Types::Array
+      attribute :alternate_ids, Valkyrie::Types::Set.of(Valkyrie::Types::ID)
       attribute :title
       attribute :member_ids, Valkyrie::Types::Array
       attribute :a_member_of, Valkyrie::Types::Array

--- a/spec/valkyrie/persistence/fedora/persister_spec.rb
+++ b/spec/valkyrie/persistence/fedora/persister_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Valkyrie::Persistence::Fedora::Persister, :wipe_fedora do
           raise 'persister must be set with `let(:persister)`' unless defined? persister
           class CustomResource < Valkyrie::Resource
             include Valkyrie::Resource::AccessControls
-            attribute :alternate_ids, Valkyrie::Types::Array
+            attribute :alternate_ids, Valkyrie::Types::Set.of(Valkyrie::Types::ID)
             attribute :title
             attribute :author
             attribute :member_ids


### PR DESCRIPTION
Other documentation might be good but this is a start.
Resolves #646.