### PR TITLE
Add id: param to find_inverse_references_by

### DIFF
--- a/lib/valkyrie/persistence/fedora/query_service.rb
+++ b/lib/valkyrie/persistence/fedora/query_service.rb
@@ -111,8 +111,10 @@ module Valkyrie::Persistence::Fedora
     # Find all resources referencing a given resource (e. g. parents)
     # *This is done by iterating through the ID of each resource referencing the resource in the query, and requesting each resource over the HTTP*
     # *Also, an initial request is made to find the URIs of the resources referencing the resource in the query*
-    def find_inverse_references_by(resource:, property:)
-      ensure_persisted(resource)
+    def find_inverse_references_by(resource: nil, id: nil, property:)
+      raise ArgumentError, "Provide resource or id" unless resource || id
+      ensure_persisted(resource) if resource
+      resource ||= find_by(id: id)
       if ordered_property?(resource: resource, property: property)
         find_inverse_references_by_ordered(resource: resource, property: property)
       else

--- a/lib/valkyrie/persistence/memory/query_service.rb
+++ b/lib/valkyrie/persistence/memory/query_service.rb
@@ -110,10 +110,12 @@ module Valkyrie::Persistence::Memory
     # @return [Array<Valkyrie::Resource>] All resources in the persistence backend
     #   which have the ID of the given `resource` in their `property` property. Not
     #   in order.
-    def find_inverse_references_by(resource:, property:)
-      ensure_persisted(resource)
+    def find_inverse_references_by(resource: nil, id: nil, property:)
+      raise ArgumentError, "Provide resource or id" unless resource || id
+      ensure_persisted(resource) if resource
+      id ||= resource.id
       find_all.select do |obj|
-        Array.wrap(obj[property]).include?(resource.id)
+        Array.wrap(obj[property]).include?(id)
       end
     end
 

--- a/lib/valkyrie/persistence/postgres/query_service.rb
+++ b/lib/valkyrie/persistence/postgres/query_service.rb
@@ -112,9 +112,11 @@ module Valkyrie::Persistence::Postgres
     # @param [Valkyrie::Resource] resource
     # @param [String] property
     # @return [Array<Valkyrie::Resource>]
-    def find_inverse_references_by(resource:, property:)
-      ensure_persisted(resource)
-      internal_array = "{\"#{property}\": [{\"id\": \"#{resource.id}\"}]}"
+    def find_inverse_references_by(resource: nil, id: nil, property:)
+      raise ArgumentError, "Provide resource or id" unless resource || id
+      ensure_persisted(resource) if resource
+      id ||= resource.id
+      internal_array = "{\"#{property}\": [{\"id\": \"#{id}\"}]}"
       run_query(find_inverse_references_query, internal_array)
     end
 

--- a/lib/valkyrie/persistence/solr/queries/find_inverse_references_query.rb
+++ b/lib/valkyrie/persistence/solr/queries/find_inverse_references_query.rb
@@ -3,14 +3,14 @@ module Valkyrie::Persistence::Solr::Queries
   # Responsible for efficiently returning all {Valkyrie::Resource}s which
   # reference a {Valkyrie::Resource} in a given property.
   class FindInverseReferencesQuery
-    attr_reader :resource, :property, :connection, :resource_factory
+    attr_reader :id, :property, :connection, :resource_factory
 
     # @param [Valkyrie::Resource] resource
     # @param [String] property
     # @param [RSolr::Client] connection
     # @param [ResourceFactory] resource_factory
-    def initialize(resource:, property:, connection:, resource_factory:)
-      @resource = resource
+    def initialize(resource: nil, id: nil, property:, connection:, resource_factory:)
+      @id = id ? id : resource.id
       @property = property
       @connection = connection
       @resource_factory = resource_factory
@@ -39,7 +39,7 @@ module Valkyrie::Persistence::Solr::Queries
     # @note the field used here is a _ssim dynamic field and the value is prefixed by "id-"
     # @return [Hash]
     def query
-      "#{property}_ssim:id-#{resource.id}"
+      "#{property}_ssim:id-#{id}"
     end
   end
 end

--- a/lib/valkyrie/persistence/solr/query_service.rb
+++ b/lib/valkyrie/persistence/solr/query_service.rb
@@ -92,9 +92,11 @@ module Valkyrie::Persistence::Solr
     # @param [Valkyrie::Resource] referenced resource
     # @param [Symbol, String] property
     # @return [Array<Valkyrie::Resource>] related resources
-    def find_inverse_references_by(resource:, property:)
-      ensure_persisted(resource)
-      Valkyrie::Persistence::Solr::Queries::FindInverseReferencesQuery.new(resource: resource, property: property, connection: connection, resource_factory: resource_factory).run
+    def find_inverse_references_by(resource: nil, id: nil, property:)
+      raise ArgumentError, "Provide resource or id" unless resource || id
+      ensure_persisted(resource) if resource
+      id ||= resource.id
+      Valkyrie::Persistence::Solr::Queries::FindInverseReferencesQuery.new(id: id, property: property, connection: connection, resource_factory: resource_factory).run
     end
 
     # Construct the Valkyrie::Persistence::CustomQueryContainer object using this query service


### PR DESCRIPTION
fixes #609
The only way to achieve this in the fedora query service is by retrieving the resource when the id is provided, due to the ordered property guarantee. This means we probably cannot deprecate the resource: parameter unless we want to be jerks to fedora users.

The concrete use case for this is #660