### PR TITLE
Query service must be set for persister shared specs

### DIFF
--- a/lib/valkyrie/specs/shared_specs/persister.rb
+++ b/lib/valkyrie/specs/shared_specs/persister.rb
@@ -2,6 +2,7 @@
 RSpec.shared_examples 'a Valkyrie::Persister' do |*flags|
   before do
     raise 'persister must be set with `let(:persister)`' unless defined? persister
+    raise 'query_service must be set with `let(:query_service)`' unless defined? query_service
     class CustomResource < Valkyrie::Resource
       include Valkyrie::Resource::AccessControls
       attribute :title


### PR DESCRIPTION
The persister shared specs depend on a `query_service` that isn't defined within the shared specs.  Existing valkyrie adapters define it with a `let()`.  This PR raises an error when it is not defined consistent with other dependent variables in to the shared specs.