### PR TITLE
Valkyrie 2.0.0.RC3

### DIFF
--- a/lib/valkyrie/version.rb
+++ b/lib/valkyrie/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Valkyrie
-  VERSION = "2.0.0rc2"
+  VERSION = "2.0.0.RC3"
 end


### PR DESCRIPTION
RC2 accidentally removed a bunch of the actual 2.0 code because of some rebasing of a reverted merge.