### PR TITLE
Namespace shared spec resources.

### DIFF
--- a/lib/valkyrie/specs/shared_specs.rb
+++ b/lib/valkyrie/specs/shared_specs.rb
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
+module Valkyrie
+  # Define a wrapper namespace for test resources.
+  module Specs
+  end
+end
 require 'valkyrie/specs/shared_specs/persister.rb'
 require 'valkyrie/specs/shared_specs/queries.rb'
 require 'valkyrie/specs/shared_specs/metadata_adapter'

--- a/lib/valkyrie/specs/shared_specs/change_set_persister.rb
+++ b/lib/valkyrie/specs/shared_specs/change_set_persister.rb
@@ -2,25 +2,25 @@
 RSpec.shared_examples 'a Valkyrie::ChangeSetPersister' do |*_flags|
   before do
     raise 'adapter must be set with `let(:change_set_persister)`' unless defined? change_set_persister
-    class CustomResource < Valkyrie::Resource
+    class Valkyrie::Specs::CustomResource < Valkyrie::Resource
       include Valkyrie::Resource::AccessControls
       attribute :title
       attribute :member_ids
       attribute :nested_resource
     end
-    class CustomChangeSet < Valkyrie::ChangeSet
+    class Valkyrie::Specs::CustomChangeSet < Valkyrie::ChangeSet
       self.fields = [:title]
     end
   end
   after do
-    Object.send(:remove_const, :CustomResource)
-    Object.send(:remove_const, :CustomChangeSet)
+    Valkyrie::Specs.send(:remove_const, :CustomResource)
+    Valkyrie::Specs.send(:remove_const, :CustomChangeSet)
   end
 
   subject { change_set_persister }
-  let(:resource_class) { CustomResource }
+  let(:resource_class) { Valkyrie::Specs::CustomResource }
   let(:resource) { resource_class.new }
-  let(:change_set) { CustomChangeSet.new(resource) }
+  let(:change_set) { Valkyrie::Specs::CustomChangeSet.new(resource) }
 
   it { is_expected.to respond_to(:save).with_keywords(:change_set) }
   it { is_expected.to respond_to(:save_all).with_keywords(:change_sets) }
@@ -32,7 +32,7 @@ RSpec.shared_examples 'a Valkyrie::ChangeSetPersister' do |*_flags|
     it "saves a resource and returns it" do
       output = subject.save(change_set: change_set)
 
-      expect(output).to be_kind_of CustomResource
+      expect(output).to be_kind_of Valkyrie::Specs::CustomResource
       expect(output).to be_persisted
     end
   end
@@ -40,7 +40,7 @@ RSpec.shared_examples 'a Valkyrie::ChangeSetPersister' do |*_flags|
   describe "#delete" do
     it "deletes a resource" do
       output = subject.save(change_set: change_set)
-      subject.delete(change_set: CustomChangeSet.new(output))
+      subject.delete(change_set: Valkyrie::Specs::CustomChangeSet.new(output))
 
       expect do
         subject.metadata_adapter.query_service.find_by(id: output.id)
@@ -50,7 +50,7 @@ RSpec.shared_examples 'a Valkyrie::ChangeSetPersister' do |*_flags|
 
   describe "#save_all" do
     it "saves multiple change_sets and returns them" do
-      change_set2 = CustomChangeSet.new(resource_class.new)
+      change_set2 = Valkyrie::Specs::CustomChangeSet.new(resource_class.new)
       output = subject.save_all(change_sets: [change_set, change_set2])
 
       expect(output.map(&:id).compact.length).to eq 2

--- a/lib/valkyrie/specs/shared_specs/queries.rb
+++ b/lib/valkyrie/specs/shared_specs/queries.rb
@@ -3,21 +3,21 @@ RSpec.shared_examples 'a Valkyrie query provider' do
   before do
     raise 'adapter must be set with `let(:adapter)`' unless
       defined? adapter
-    class CustomResource < Valkyrie::Resource
+    class Valkyrie::Specs::CustomResource < Valkyrie::Resource
       attribute :alternate_ids, Valkyrie::Types::Set.of(Valkyrie::Types::ID)
       attribute :title
       attribute :member_ids, Valkyrie::Types::Array
       attribute :a_member_of, Valkyrie::Types::Array
       attribute :an_ordered_member_of, Valkyrie::Types::Array.meta(ordered: true)
     end
-    class SecondResource < Valkyrie::Resource
+    class Valkyrie::Specs::SecondResource < Valkyrie::Resource
     end
   end
   after do
-    Object.send(:remove_const, :CustomResource)
-    Object.send(:remove_const, :SecondResource)
+    Valkyrie::Specs.send(:remove_const, :CustomResource)
+    Valkyrie::Specs.send(:remove_const, :SecondResource)
   end
-  let(:resource_class) { CustomResource }
+  let(:resource_class) { Valkyrie::Specs::CustomResource }
   let(:query_service) { adapter.query_service } unless defined? query_service
   let(:persister) { adapter.persister }
   subject { adapter.query_service }
@@ -47,12 +47,12 @@ RSpec.shared_examples 'a Valkyrie query provider' do
   describe ".find_all_of_model" do
     it "returns all of that model" do
       persister.save(resource: resource_class.new)
-      resource2 = persister.save(resource: SecondResource.new)
+      resource2 = persister.save(resource: Valkyrie::Specs::SecondResource.new)
 
-      expect(query_service.find_all_of_model(model: SecondResource).map(&:id)).to contain_exactly resource2.id
+      expect(query_service.find_all_of_model(model: Valkyrie::Specs::SecondResource).map(&:id)).to contain_exactly resource2.id
     end
     it "returns an empty array if there are none" do
-      expect(query_service.find_all_of_model(model: SecondResource).to_a).to eq []
+      expect(query_service.find_all_of_model(model: Valkyrie::Specs::SecondResource).to_a).to eq []
     end
   end
 
@@ -94,7 +94,7 @@ RSpec.shared_examples 'a Valkyrie query provider' do
     end
 
     it 'raises a Valkyrie::Persistence::ObjectNotFoundError when persisted objects do not have alternate_ids' do
-      persister.save(resource: SecondResource.new)
+      persister.save(resource: Valkyrie::Specs::SecondResource.new)
       expect { query_service.find_by_alternate_identifier(alternate_identifier: Valkyrie::ID.new("123123123")) }.to raise_error ::Valkyrie::Persistence::ObjectNotFoundError
     end
 
@@ -193,7 +193,7 @@ RSpec.shared_examples 'a Valkyrie query provider' do
       end
 
       context "when the model doesn't have member_ids" do
-        let(:parent) { persister.save(resource: SecondResource.new) }
+        let(:parent) { persister.save(resource: Valkyrie::Specs::SecondResource.new) }
 
         it "returns an empty array" do
           expect(subject.to_a).to eq []
@@ -202,12 +202,12 @@ RSpec.shared_examples 'a Valkyrie query provider' do
     end
 
     context "filtering by model" do
-      subject { query_service.find_members(resource: parent, model: SecondResource) }
+      subject { query_service.find_members(resource: parent, model: Valkyrie::Specs::SecondResource) }
 
       context "when the object has members" do
-        let(:child1) { persister.save(resource: SecondResource.new) }
+        let(:child1) { persister.save(resource: Valkyrie::Specs::SecondResource.new) }
         let(:child2) { persister.save(resource: resource_class.new) }
-        let(:child3) { persister.save(resource: SecondResource.new) }
+        let(:child3) { persister.save(resource: Valkyrie::Specs::SecondResource.new) }
         let(:parent) { persister.save(resource: resource_class.new(member_ids: [child3.id, child2.id, child1.id])) }
 
         it "returns all a resource's members in order" do
@@ -286,7 +286,7 @@ RSpec.shared_examples 'a Valkyrie query provider' do
           child = persister.save(resource: resource_class.new(a_member_of: [parent.id]))
           child2 = persister.save(resource: resource_class.new(a_member_of: [parent.id, parent2.id, parent.id]))
           persister.save(resource: resource_class.new)
-          persister.save(resource: SecondResource.new)
+          persister.save(resource: Valkyrie::Specs::SecondResource.new)
 
           expect(query_service.find_inverse_references_by(resource: parent, property: :a_member_of).map(&:id).to_a).to contain_exactly child.id, child2.id
         end
@@ -304,7 +304,7 @@ RSpec.shared_examples 'a Valkyrie query provider' do
           child = persister.save(resource: resource_class.new(an_ordered_member_of: [parent.id]))
           child2 = persister.save(resource: resource_class.new(an_ordered_member_of: [parent.id, parent.id]))
           persister.save(resource: resource_class.new)
-          persister.save(resource: SecondResource.new)
+          persister.save(resource: Valkyrie::Specs::SecondResource.new)
 
           expect(query_service.find_inverse_references_by(resource: parent, property: :an_ordered_member_of).map(&:id).to_a).to contain_exactly child.id, child2.id
         end
@@ -318,7 +318,7 @@ RSpec.shared_examples 'a Valkyrie query provider' do
         child = persister.save(resource: resource_class.new(a_member_of: [parent.id]))
         child2 = persister.save(resource: resource_class.new(a_member_of: [parent.id, parent2.id, parent.id]))
         persister.save(resource: resource_class.new)
-        persister.save(resource: SecondResource.new)
+        persister.save(resource: Valkyrie::Specs::SecondResource.new)
 
         expect(query_service.find_inverse_references_by(id: parent.id, property: :a_member_of).map(&:id).to_a).to contain_exactly child.id, child2.id
       end
@@ -364,7 +364,7 @@ RSpec.shared_examples 'a Valkyrie query provider' do
     end
 
     context "when the model doesn't have member_ids" do
-      let(:child1) { persister.save(resource: SecondResource.new) }
+      let(:child1) { persister.save(resource: Valkyrie::Specs::SecondResource.new) }
 
       it "returns an empty array if there are none" do
         expect(query_service.find_parents(resource: child1).to_a).to eq []

--- a/lib/valkyrie/specs/shared_specs/resource.rb
+++ b/lib/valkyrie/specs/shared_specs/resource.rb
@@ -52,16 +52,16 @@ RSpec.shared_examples 'a Valkyrie::Resource' do
 
   describe "#human_readable_type" do
     before do
-      class MyCustomResource < Valkyrie::Resource
+      class Valkyrie::Specs::MyCustomResource < Valkyrie::Resource
         attribute :title, Valkyrie::Types::Set
       end
     end
 
     after do
-      Object.send(:remove_const, :MyCustomResource)
+      Valkyrie::Specs.send(:remove_const, :MyCustomResource)
     end
 
-    subject(:my_custom_resource) { MyCustomResource.new }
+    subject(:my_custom_resource) { Valkyrie::Specs::MyCustomResource.new }
 
     it "returns a human readable rendering of the resource class" do
       expect(my_custom_resource.human_readable_type).to eq "My Custom Resource"

--- a/lib/valkyrie/specs/shared_specs/solr_indexer.rb
+++ b/lib/valkyrie/specs/shared_specs/solr_indexer.rb
@@ -11,7 +11,7 @@ RSpec.shared_examples 'a Valkyrie::Persistence::Solr::Indexer' do |*_flags|
     }
   end
   let(:resource) do
-    Resource.new(
+    Valkyrie::Specs::Resource.new(
       id: "1",
       internal_resource: 'Resource',
       attributes: attributes
@@ -20,7 +20,7 @@ RSpec.shared_examples 'a Valkyrie::Persistence::Solr::Indexer' do |*_flags|
   let(:indexer) { described_class.new(resource: resource) }
 
   before do
-    class Resource < Valkyrie::Resource
+    class Valkyrie::Specs::Resource < Valkyrie::Resource
       attribute :title, Valkyrie::Types::Set
       attribute :author, Valkyrie::Types::Set
       attribute :birthday, Valkyrie::Types::DateTime.optional
@@ -29,7 +29,7 @@ RSpec.shared_examples 'a Valkyrie::Persistence::Solr::Indexer' do |*_flags|
   end
 
   after do
-    Object.send(:remove_const, :Resource)
+    Valkyrie::Specs.send(:remove_const, :Resource)
   end
 
   describe '#to_solr' do

--- a/lib/valkyrie/specs/shared_specs/storage_adapter.rb
+++ b/lib/valkyrie/specs/shared_specs/storage_adapter.rb
@@ -5,11 +5,11 @@ RSpec.shared_examples 'a Valkyrie::StorageAdapter' do
       defined? storage_adapter
     raise 'file must be set with `let(:file)`' unless
       defined? file
-    class CustomResource < Valkyrie::Resource
+    class Valkyrie::Specs::CustomResource < Valkyrie::Resource
     end
   end
   after do
-    Object.send(:remove_const, :CustomResource)
+    Valkyrie::Specs.send(:remove_const, :CustomResource)
   end
   subject { storage_adapter }
   it { is_expected.to respond_to(:handles?).with_keywords(:id) }
@@ -18,7 +18,7 @@ RSpec.shared_examples 'a Valkyrie::StorageAdapter' do
   it { is_expected.to respond_to(:upload).with_keywords(:file, :resource, :original_filename) }
 
   it "can upload, validate, re-fetch, and delete a file" do
-    resource = CustomResource.new(id: "test")
+    resource = Valkyrie::Specs::CustomResource.new(id: "test")
     sha1 = Digest::SHA1.file(file).to_s
     size = file.size
     expect(uploaded_file = storage_adapter.upload(file: file, original_filename: 'foo.jpg', resource: resource)).to be_kind_of Valkyrie::StorageAdapter::File


### PR DESCRIPTION
Sometimes ones like `Resource` were conflicting with constants defined
in the Valkyrie applications that used them, breaking specs.