### PR TITLE
Remove ActiveTriples as a dependency.

### DIFF
--- a/lib/valkyrie/persistence/fedora.rb
+++ b/lib/valkyrie/persistence/fedora.rb
@@ -3,7 +3,6 @@
 module Valkyrie::Persistence
   # Implements the DataMapper Pattern to store metadata into Fedora
   module Fedora
-    require 'active_triples'
     require 'active_fedora'
     require 'valkyrie/persistence/fedora/permissive_schema'
     require 'valkyrie/persistence/fedora/metadata_adapter'

--- a/valkyrie.gemspec
+++ b/valkyrie.gemspec
@@ -33,7 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'pg'
   spec.add_dependency 'json-ld'
   spec.add_dependency 'json'
-  spec.add_dependency 'active-triples'
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
It was only being used for a very small and very internal reason. It was
easy to remove, so why not do so?