### PR TITLE
Remove Coveralls.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,9 @@ jobs:
       - run:
           name: Run Specs
           command: bundle exec rake docker:spec
+      - store_artifacts:
+          path: coverage
+          destination: coverage
 workflows:
   version: 2
   build:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Valkyrie is a gem for enabling multiple backends for storage of files and metada
 
 Code: [![Version](https://badge.fury.io/rb/valkyrie.png)](http://badge.fury.io/rb/valkyrie)
 [![Build Status](https://circleci.com/gh/samvera-labs/valkyrie.svg?style=svg)](https://circleci.com/gh/samvera-labs/valkyrie)
-[![Coverage Status](https://coveralls.io/repos/github/samvera-labs/valkyrie/badge.svg?branch=master)](https://coveralls.io/github/samvera-labs/valkyrie?branch=master)
+![Coverage Status](https://img.shields.io/badge/Coverage-100-brightgreen.svg)
 [![Stories in Ready](https://badge.waffle.io/samvera-labs/valkyrie.png?label=ready&title=Ready)](https://waffle.io/samvera-labs/valkyrie)
 
 Docs: [![Contribution Guidelines](http://img.shields.io/badge/CONTRIBUTING-Guidelines-blue.svg)](./CONTRIBUTING.md)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,16 +2,10 @@
 ENV['RACK_ENV'] = 'test'
 ENV['RAILS_ENV'] = 'test'
 require 'simplecov'
-require 'coveralls'
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
-  [
-    SimpleCov::Formatter::HTMLFormatter,
-    Coveralls::SimpleCov::Formatter
-  ]
-)
 SimpleCov.start do
   add_filter 'spec'
   add_filter 'vendor'
+  minimum_coverage 100
 end
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require 'active_fedora'

--- a/valkyrie.gemspec
+++ b/valkyrie.gemspec
@@ -43,7 +43,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "database_cleaner"
   spec.add_development_dependency "simplecov"
-  spec.add_development_dependency "coveralls"
   spec.add_development_dependency "bixby"
   spec.add_development_dependency 'yard'
   spec.add_development_dependency 'solr_wrapper'


### PR DESCRIPTION
It just slows down our PR process, especially when we require 100% coverage for PRs to be merged.