### PR TITLE
Don't require a specific error message in shared specs.

### DIFF
--- a/lib/valkyrie/specs/shared_specs/persister.rb
+++ b/lib/valkyrie/specs/shared_specs/persister.rb
@@ -369,7 +369,7 @@ RSpec.shared_examples 'a Valkyrie::Persister' do |*flags|
           # update the resource in the datastore to make its token stale
           persister.save(resource: resource)
 
-          expect { persister.save(resource: resource) }.to raise_error(Valkyrie::Persistence::StaleObjectError, "The object #{resource.id} has been updated by another process.")
+          expect { persister.save(resource: resource) }.to raise_error(Valkyrie::Persistence::StaleObjectError)
         end
       end
 
@@ -443,7 +443,7 @@ RSpec.shared_examples 'a Valkyrie::Persister' do |*flags|
           persister.save(resource: resource2)
 
           expect { persister.save_all(resources: [resource1, resource2, resource3]) }
-            .to raise_error(Valkyrie::Persistence::StaleObjectError, "One or more resources have been updated by another process.")
+            .to raise_error(Valkyrie::Persistence::StaleObjectError)
         end
       end
     end


### PR DESCRIPTION
Closes #849