### PR TITLE
Use delete_prefix in Valkyrie::Storage::Disk#file_path

### DIFF
--- a/lib/valkyrie/storage/disk.rb
+++ b/lib/valkyrie/storage/disk.rb
@@ -41,7 +41,7 @@ module Valkyrie::Storage
     end
 
     def file_path(id)
-      id.to_s.gsub(/^#{Regexp.escape(protocol)}/, '')
+      id.to_s.delete_prefix(protocol)
     end
 
     # Return the file associated with the given identifier


### PR DESCRIPTION
Proposing an alternative implementation of Valkyrie::Storage::Disk#file_path that I find easier to read.