### PR TITLE
Fix to #992: performance bottleneck in Fedora 6 persister

### DIFF
--- a/lib/valkyrie/persistence/fedora/persister/model_converter.rb
+++ b/lib/valkyrie/persistence/fedora/persister/model_converter.rb
@@ -42,7 +42,11 @@ module Valkyrie::Persistence::Fedora
       # @see https://www.w3.org/TR/ldp/#ldpc
       # @return [Ldp::Container::Basic]
       def graph_resource
-        @graph_resource ||= ::Ldp::Container::Basic.new(connection, subject, nil, base_path)
+        # If the resource is a nested resource with a hashed URI, we don't want to query Fedora for a URI formed from this resource ID, because it will return everything at the base_path, resulting in a unnecessary work (clearing out the graph)
+        # Passing nil here returns an empty graph, which doesn't seem to cause problems
+        s = resource.id.to_s.start_with?("#") ? nil : subject
+        @graph_resource ||= ::Ldp::Container::Basic.new(connection, s, nil, base_path)
+
       end
 
       # Generate a URI from the Valkyrie Resource ID to be used as the RDF subject for Fedora LDP resources

--- a/lib/valkyrie/persistence/fedora/persister/model_converter.rb
+++ b/lib/valkyrie/persistence/fedora/persister/model_converter.rb
@@ -42,11 +42,13 @@ module Valkyrie::Persistence::Fedora
       # @see https://www.w3.org/TR/ldp/#ldpc
       # @return [Ldp::Container::Basic]
       def graph_resource
-        # If the resource is a nested resource with a hashed URI, we don't want to query Fedora for a URI formed from this resource ID, because it will return everything at the base_path, resulting in a unnecessary work (clearing out the graph)
+        # If the resource is a nested resource with a hashed URI,
+        # we don't want to query Fedora for a URI formed from this resource ID,
+        # because it will return everything at the base_path,
+        # resulting in a unnecessary work (clearing out the graph)
         # Passing nil here returns an empty graph, which doesn't seem to cause problems
         s = resource.id.to_s.start_with?("#") ? nil : subject
         @graph_resource ||= ::Ldp::Container::Basic.new(connection, s, nil, base_path)
-
       end
 
       # Generate a URI from the Valkyrie Resource ID to be used as the RDF subject for Fedora LDP resources


### PR DESCRIPTION
The existing implementation mishandles [hashed URI's](https://wiki.lyrasis.org/display/FF/Design+-+Hash+URI+Fragments) when adding properties as nested resources. Currently, the model-converter code creates a graph based on a hashed-URI fragment, but a query to the Fedora API (via `::Ldp::Container::Basic.new`), given this fragment, returns all resources at the repository's base path, which creates a performance bottleneck. 

The graph, as far as I can tell, does not need to contain any ancestors in order to persist the properties associated with the nested resource; in fact, the code [deletes](https://github.com/gwu-libraries/valkyrie/blob/40dc581f7e944825ceac59845cf60a16d5ac235c/lib/valkyrie/persistence/fedora/persister/model_converter.rb#L21) any such ancestors before adding the new property. 

This fix inserts a check for a hashed URI and defaults to a `nil` argument for to `::Ldp::Container::Basic.new` (in lieu of a malformed URI). 

All Valkyrie tests from `main` pass. I can also confirm, from testing this patch in a fairly vanilla Hyrax-5 instance with Fedora 6, that the performance bottleneck observed when creating new works disappears. 

I have not run the Hyrax 5 tests. I am happy to do so, but I'm heading out of town for a couple of weeks, so I wouldn't be able to get to that until the second half of May. 

Thanks for your assistance with this one, @tpendragon.