### PR TITLE
Keep one-key Hash entries whole on Postgres read

### DIFF
--- a/lib/valkyrie/persistence/shared/json_value_mapper.rb
+++ b/lib/valkyrie/persistence/shared/json_value_mapper.rb
@@ -89,11 +89,17 @@ module Valkyrie::Persistence::Shared
     class NestedRecord < ::Valkyrie::ValueMapper
       PostgresValue.register(self)
 
-      # Determines whether or not a value is a Hash containing multiple keys
+      # Determines whether or not a value is a non-empty Hash.
+      #
+      # Any non-empty Hash is a nested record. A single-key Hash must be claimed
+      # here too: otherwise it falls through to EnumeratorValue (a Hash responds
+      # to #each), which unwraps it to a loose [key, value] pair and loses the
+      # entry. The RDF-literal, ID, and URI shapes are recognized by mappers
+      # registered ahead of this one, so they are unaffected.
       # @param [Object] value
       # @return [Boolean]
       def self.handles?(value)
-        value.is_a?(Hash) && value.keys.length > 1
+        value.is_a?(Hash) && !value.empty?
       end
 
       # Generates a Hash derived from the JSON for the value

--- a/spec/valkyrie/persistence/postgres/single_key_hash_round_trip_spec.rb
+++ b/spec/valkyrie/persistence/postgres/single_key_hash_round_trip_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+# A Hash-typed attribute holding an array of one-key entry hashes must survive a
+# save/reload with each entry intact. On the way out of Postgres, JSONValueMapper
+# unwraps a one-key Hash to its [key, value] pair (a Hash responds to #each), so
+# [{ name: 'a' }, { role: 'b' }] would otherwise come back flattened. Keys are
+# symbolized on read, matching how multi-key (nested) hashes already round-trip.
+RSpec.describe Valkyrie::Persistence::Postgres::Persister do
+  let(:adapter) { Valkyrie::Persistence::Postgres::MetadataAdapter.new }
+  let(:persister) { adapter.persister }
+  let(:query_service) { adapter.query_service }
+
+  before do
+    class HashEntryResource < Valkyrie::Resource
+      attribute :entries, Valkyrie::Types::Array.of(Valkyrie::Types::Anything)
+    end
+  end
+  after { Object.send(:remove_const, :HashEntryResource) }
+
+  it 'keeps several one-key entry hashes as separate hashes' do
+    saved = persister.save(resource: HashEntryResource.new(entries: [{ 'name' => 'Ada' }, { 'role' => 'Editor' }]))
+    reloaded = query_service.find_by(id: saved.id)
+    expect(reloaded.entries).to eq([{ name: 'Ada' }, { role: 'Editor' }])
+  end
+
+  it 'keeps a single one-key entry hash as a hash' do
+    saved = persister.save(resource: HashEntryResource.new(entries: [{ 'value' => 'doi:10.0/abc' }]))
+    reloaded = query_service.find_by(id: saved.id)
+    expect(reloaded.entries).to eq([{ value: 'doi:10.0/abc' }])
+  end
+
+  it 'leaves a multi-key entry hash intact (regression guard)' do
+    saved = persister.save(resource: HashEntryResource.new(entries: [{ 'name' => 'Ada', 'role' => 'Author' }]))
+    reloaded = query_service.find_by(id: saved.id)
+    expect(reloaded.entries).to eq([{ name: 'Ada', role: 'Author' }])
+  end
+end


### PR DESCRIPTION
## Summary

A `Hash` attribute holding an array of single-key entry hashes loses its entries when read back from Postgres. For example, saving:

```ruby
entries: [{ 'name' => 'Ada' }, { 'role' => 'Editor' }]
```

reads back as `["name", "Ada", "role", "Editor"]`-style loose pairs rather than two hashes — and two single-key entries become indistinguishable from one two-key entry, so they can silently merge. The stored JSON is correct; only the read conversion loses the structure.

## Cause

In `JSONValueMapper`, the value mappers are tried in registration order. A `Hash` is claimed by `NestedRecord` only when it has more than one key:

```ruby
def self.handles?(value)
  value.is_a?(Hash) && value.keys.length > 1
end
```

A single-key Hash falls past `NestedRecord` to `EnumeratorValue`, whose `handles?` is `value.respond_to?(:each)` — true for a Hash. `EnumeratorValue` then unwraps the one-key Hash to its `[key, value]` pair. So `{ 'name' => 'Ada' }` becomes `["name", "Ada"]`, and an array of such entries is flattened into loose pairs before any consumer sees it.

## Fix

Recognize every non-empty Hash as a nested record, not only multi-key ones:

```ruby
def self.handles?(value)
  value.is_a?(Hash) && !value.empty?
end
```

The RDF-literal (`@value`), ID (`id`), and URI (`@id`) hash shapes are matched by `HashValue` / `IDValue` / `URIValue`, which are registered ahead of `NestedRecord`, so they are unaffected. The only Hashes that previously reached `EnumeratorValue` were plain single-key entry hashes — exactly the ones being lost — so this claims them and leaves every other value on its existing path. `JSONValueMapper` is used only by the Postgres `orm_converter`; the Fedora and Solr adapters have their own mappers and are not touched.

Keys are symbolized on read, matching how multi-key (nested) hashes already round-trip.

## Downstream context

Hyrax works around this today with a scoped read override on its compound-metadata attributes (samvera/hyrax#7487 — it reads the affected attributes from the raw row before this unwrap). With this upstream fix, that workaround can eventually be dropped: the boundaries are preserved at the source for every consumer, not repaired per-attribute downstream.