### PR TITLE
Set binary mode on StringIO stream

### DIFF
--- a/lib/valkyrie/specs/shared_specs/storage_adapter.rb
+++ b/lib/valkyrie/specs/shared_specs/storage_adapter.rb
@@ -94,6 +94,7 @@ RSpec.shared_examples 'a Valkyrie::StorageAdapter' do
     expect(file).to respond_to(:read).with(0).arguments
     expect(file).to respond_to(:rewind).with(0).arguments
     expect(file.stream).to respond_to(:read)
+    expect(file.stream.external_encoding).to eq(Encoding::ASCII_8BIT)
     new_file = Tempfile.new
     expect { IO.copy_stream(file, new_file) }.not_to raise_error
 

--- a/lib/valkyrie/storage/fedora.rb
+++ b/lib/valkyrie/storage/fedora.rb
@@ -196,7 +196,7 @@ module Valkyrie::Storage
 
     # @return [StringIO]
     def response(id:)
-      io = StringIO.new
+      io = StringIO.new.binmode
       response = connection.http.get(fedora_identifier(id: id)) do |request|
         request.options.on_data = proc { |chunk, _size| io.write(chunk) }
       end


### PR DESCRIPTION
#994 introduced a change in the encoding of the file IO that a hyrax spec is failing on in [hyrax #7562](https://github.com/samvera/hyrax/pull/7562). Text data is the default encoding for StringIO objects. Setting the encoding to binary/ASCII_8BIT restores previous behavior.